### PR TITLE
Allow overriding of the git.destination fetch and push references in …

### DIFF
--- a/java/com/google/copybara/git/GitDestinationOptions.java
+++ b/java/com/google/copybara/git/GitDestinationOptions.java
@@ -45,4 +45,12 @@ public final class GitDestinationOptions implements Option {
   @Parameter(names = "--git-destination-url",
       description = "If set, overrides the git destination URL.")
   String url = null;
+
+  @Parameter(names = "--git-destination-fetch",
+      description = "If set, overrides the git destination fetch reference.")
+  String fetch = null;
+
+  @Parameter(names = "--git-destination-push",
+      description = "If set, overrides the git destination push reference.")
+  String push = null;
 }

--- a/java/com/google/copybara/git/GitModule.java
+++ b/java/com/google/copybara/git/GitModule.java
@@ -145,8 +145,8 @@ public class GitModule implements OptionsAwareModule {
       GitDestinationOptions destinationOptions = self.options.get(GitDestinationOptions.class);
       return new GitDestination(
           checkNotEmpty(destinationUrl(url, destinationOptions), "url", location),
-          checkNotEmpty(fetch, "fetch", location),
-          checkNotEmpty(push, "push", location),
+          checkNotEmpty(fetch(fetch, destinationOptions), "fetch", location),
+          checkNotEmpty(push(push, destinationOptions), "push", location),
           destinationOptions,
           self.options.get(GeneralOptions.class).isVerbose(),
           new DefaultCommitGenerator(),
@@ -157,6 +157,14 @@ public class GitModule implements OptionsAwareModule {
 
   private static String destinationUrl(String url, GitDestinationOptions destinationOptions) {
     return Strings.isNullOrEmpty(destinationOptions.url) ? url : destinationOptions.url;
+  }
+
+  private static String fetch(String fetch, GitDestinationOptions destinationOptions) {
+    return Strings.isNullOrEmpty(destinationOptions.fetch) ? fetch : destinationOptions.fetch;
+  }
+
+  private static String push(String push, GitDestinationOptions destinationOptions) {
+    return Strings.isNullOrEmpty(destinationOptions.push) ? push : destinationOptions.push;
   }
 
   @SkylarkSignature(name = "gerrit_destination", returnType = GerritDestination.class,


### PR DESCRIPTION
…the CLI.

After this change a user can overwrite the git.destination() fetch and push references by
passing a command line flag. This is particularly useful when a user wants to test the configuration or when a local git is used as a wrapper of other destination type (internal usage).

This is pretty much a copy-and-paste change of @mikelalcon's 2775e1971b7cb799199d1004d4545ef238d9f9ad commit. Unfortunately, my Java testing skills are non-existent and I was unable to figure out the right way to test the overrides in javatests/com/google/copybara/git/GitDestinationTest.java.

Can someone pick this up and add the appropriate tests (or teach me)? We would like this internally.