### PR TITLE
Use 'git add -f' to avoid failures with .gitignore rules.

### DIFF
--- a/java/com/google/copybara/git/AddExcludedFilesToIndexVisitor.java
+++ b/java/com/google/copybara/git/AddExcludedFilesToIndexVisitor.java
@@ -76,7 +76,7 @@ final class AddExcludedFilesToIndexVisitor extends SimpleFileVisitor<Path> {
   public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
     if (!destinationFiles.matches(file)) {
       try {
-        repo.simpleCommand("add", "--", file.toString());
+        repo.simpleCommand("add", "-f", "--", file.toString());
       } catch (RepoException e) {
         throw new IOException(e);
       }
@@ -91,7 +91,7 @@ final class AddExcludedFilesToIndexVisitor extends SimpleFileVisitor<Path> {
     Files.walkFileTree(repo.getWorkTree(), this);
     for (String addBackSubmodule : addBackSubmodules) {
       repo.simpleCommand("reset", "--", "--quiet", addBackSubmodule);
-      repo.simpleCommand("add", "--", addBackSubmodule);
+      repo.simpleCommand("add", "-f", "--", addBackSubmodule);
     }
   }
 }

--- a/java/com/google/copybara/git/GitDestination.java
+++ b/java/com/google/copybara/git/GitDestination.java
@@ -205,7 +205,7 @@ public final class GitDestination implements Destination {
 
       console.progress("Git Destination: Creating a local commit");
       GitRepository alternate = scratchClone.withWorkTree(transformResult.getPath());
-      alternate.simpleCommand("add", "--all");
+      alternate.simpleCommand("add", "-f", "--all");
 
       excludedAdder.add();
 


### PR DESCRIPTION
If the repo being imported includes `.gitignore` rules that exclude its own files, then Copybara fails to import to a Git destination with an error like:

```shell
Copybara source mover
Task: Git Destination: Creating a local commit
ERROR: com.google.copybara.RepoException: Error executing 'git': Process exited with status 1. Stderr: 
The following paths are ignored by one of your .gitignore files:
FILE_THAT_IS_IGNORED
Use -f if you really want to add them.
```

`bazel test ...:all` passes successfully.