### PR TITLE
made getAvailableToMigrate public for programmatic access

### DIFF
--- a/java/com/google/copybara/Info.java
+++ b/java/com/google/copybara/Info.java
@@ -87,7 +87,7 @@ public abstract class Info<O extends Revision> {
      * recent change available at this moment.
      */
     @Nullable
-    public O getLastAvailableToMigrate() {
+    O getLastAvailableToMigrate() {
       Optional<O> lastAvailable =
           getAvailableToMigrate()
               .stream()

--- a/java/com/google/copybara/Info.java
+++ b/java/com/google/copybara/Info.java
@@ -99,7 +99,7 @@ public abstract class Info<O extends Revision> {
     /**
      * Returns a list of the next available {@link Change}s to migrate from the origin.
      */
-    abstract ImmutableList<Change<O>> getAvailableToMigrate();
+    public abstract ImmutableList<Change<O>> getAvailableToMigrate();
 
     @Override
     public String toString() {


### PR DESCRIPTION
I changed getLastAvailableToMigrate previously but it was a mistake. I need getAvailableToMigrate.
If you'd like I can add another commit to this PR to remove the public modifier from getLastAvailableToMigrate