### PR TITLE
Add Show Description functionality to metadata.squash_notes

### DIFF
--- a/java/com/google/copybara/transform/metadata/MetadataModule.java
+++ b/java/com/google/copybara/transform/metadata/MetadataModule.java
@@ -77,6 +77,9 @@ public class MetadataModule {
           @Param(name = "show_author", type = Boolean.class,
               doc = "If each change author should be present in the notes",
               defaultValue = "True"),
+          @Param(name = "show_description", type = Boolean.class,
+              doc = "If each change description should be present in the notes",
+              defaultValue = "True"),
           @Param(name = "oldest_first", type = Boolean.class,
               doc = "If set to true, the list shows the oldest changes first. Otherwise"
                   + " it shows the changes in descending order.",
@@ -104,6 +107,17 @@ public class MetadataModule {
           + "  - a4321bcde first commit description\n"
           + "  - 1234abcde second commit description\n"
           + "```\n")
+  @Example(title = "Removing description",
+      before = "",
+      code = "metadata.squash_notes(\"Changes for Project Foo:\\n\",\n"
+          + "    show_description = False,\n"
+          + ")",
+      after = "This transform will generate changes like:\n\n"
+          + "```\n"
+          + "Changes for Project Foo:\n\n"
+          + "  - a4321bcde by Foo Bar <foo@bar.com>\n"
+          + "  - 1234abcde by Foo Bar <foo@bar.com>\n"
+          + "```\n")
   @Example(title = "Showing the full message",
       before = "",
       code = "metadata.squash_notes(\n"
@@ -127,10 +141,10 @@ public class MetadataModule {
           + "Extended text\n" + "```\n")
   static final BuiltinFunction SQUASH_NOTES = new BuiltinFunction("squash_notes") {
     public Transformation invoke(MetadataModule self, String prefix, Integer max,
-        Boolean compact, Boolean showRef, Boolean showAuthor, Boolean oldestFirst,
+        Boolean compact, Boolean showRef, Boolean showAuthor, Boolean showDescription, Boolean oldestFirst,
         Location location) throws EvalException {
       return new MetadataSquashNotes(SkylarkUtil.checkNotEmpty(prefix, "prefix", location),
-          max, compact, showRef, showAuthor, oldestFirst);
+          max, compact, showRef, showAuthor, showDescription, oldestFirst);
     }
   };
 

--- a/java/com/google/copybara/transform/metadata/MetadataSquashNotes.java
+++ b/java/com/google/copybara/transform/metadata/MetadataSquashNotes.java
@@ -25,7 +25,9 @@ import com.google.copybara.ValidationException;
 import com.google.copybara.transform.ExplicitReversal;
 import com.google.copybara.transform.IntentionalNoop;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Generates a message that includes a constant prefix text and a list of changes
@@ -71,31 +73,33 @@ public class MetadataSquashNotes implements Transformation {
       if (counter == max) {
         break;
       }
+      ArrayList<String> summary = new ArrayList<>();
       if (compact) {
         sb.append("  - ");
         if (showRef) {
-          sb.append(c.refAsString());
+          summary.add(c.refAsString());
         }
         if (showDescription) {
-          sb.append(" ");
-          sb.append(cutIfLong(c.firstLineMessage()));
+          summary.add(cutIfLong(c.firstLineMessage()));
         }
         if (showAuthor) {
-          sb.append(" by ");
-          sb.append(c.getAuthor());
+          summary.add("by " + c.getAuthor().toString());
         }
+        sb.append(summary.stream()
+                  .collect(Collectors.joining(" ")));
         sb.append("\n");
       } else {
         sb.append("--\n");
         if (showRef) {
-          sb.append(c.refAsString());
+          summary.add(c.refAsString());
         } else {
-          sb.append("Change ").append(i + 1).append(" of ").append(changes.size());
+          summary.add(String.format("Change %s of %s", i + 1, changes.size()));
         }
         if (showAuthor) {
-          sb.append(" by ");
-          sb.append(c.getAuthor());
+          summary.add("by " + c.getAuthor().toString());
         }
+        sb.append(summary.stream()
+            .collect(Collectors.joining(" ")));
         if (showDescription) {
           sb.append(":\n\n");
           sb.append(c.getMessage());

--- a/java/com/google/copybara/transform/metadata/MetadataSquashNotes.java
+++ b/java/com/google/copybara/transform/metadata/MetadataSquashNotes.java
@@ -36,17 +36,19 @@ public class MetadataSquashNotes implements Transformation {
   private final String prefix;
   private final int max;
   private final boolean compact;
-  private final boolean showRef;
   private final boolean showAuthor;
+  private final boolean showDescription;
+  private final boolean showRef;
   private final boolean oldestFirst;
 
   public MetadataSquashNotes(String prefix, int max, boolean compact, boolean showRef,
-      boolean showAuthor, boolean oldestFirst) {
+      boolean showAuthor, boolean showDescription, boolean oldestFirst) {
     this.prefix = prefix;
     this.max = max;
     this.compact = compact;
     this.showRef = showRef;
     this.showAuthor = showAuthor;
+    this.showDescription = showDescription;
     this.oldestFirst = oldestFirst;
   }
 
@@ -73,9 +75,11 @@ public class MetadataSquashNotes implements Transformation {
         sb.append("  - ");
         if (showRef) {
           sb.append(c.refAsString());
-          sb.append(" ");
         }
-        sb.append(cutIfLong(c.firstLineMessage()));
+        if (showDescription) {
+          sb.append(" ");
+          sb.append(cutIfLong(c.firstLineMessage()));
+        }
         if (showAuthor) {
           sb.append(" by ");
           sb.append(c.getAuthor());
@@ -92,8 +96,10 @@ public class MetadataSquashNotes implements Transformation {
           sb.append(" by ");
           sb.append(c.getAuthor());
         }
-        sb.append(":\n\n");
-        sb.append(c.getMessage());
+        if (showDescription) {
+          sb.append(":\n\n");
+          sb.append(c.getMessage());
+        }
         sb.append("\n");
       }
       counter++;

--- a/javatests/com/google/copybara/transform/metadata/MetadataModuleTest.java
+++ b/javatests/com/google/copybara/transform/metadata/MetadataModuleTest.java
@@ -168,6 +168,23 @@ public class MetadataModuleTest {
   }
 
   @Test
+  public void testMessageTransformerForNoDescription() throws Exception {
+    runWorkflow(WorkflowMode.SQUASH, ""
+        + "metadata.squash_notes("
+        + "  prefix = 'Importing foo project:\\n\\n',"
+        + "  show_description = False,"
+        + ")");
+    ProcessedChange change = Iterables.getOnlyElement(destination.processed);
+    assertThat(change.getChangesSummary())
+        .isEqualTo(""
+            + "Importing foo project:\n"
+            + "\n"
+            + "  - 2 by Foo Baz <foo@baz.com>\n"
+            + "  - 1 by Foo Bar <foo@bar.com>\n");
+    assertThat(change.getAuthor()).isEqualTo(DEFAULT_AUTHOR);
+  }
+
+  @Test
   public void testMessageTransformerForSquashExtended() throws Exception {
     runWorkflow(WorkflowMode.SQUASH, ""
         + "metadata.squash_notes("
@@ -190,6 +207,25 @@ public class MetadataModuleTest {
             + "second commit\n"
             + "\n"
             + "Extended text\n");
+    assertThat(change.getAuthor()).isEqualTo(DEFAULT_AUTHOR);
+  }
+
+  @Test
+  public void testMessageTransformerForSquashExtendedNoDescription() throws Exception {
+    runWorkflow(WorkflowMode.SQUASH, ""
+        + "metadata.squash_notes("
+        + "  prefix = 'Importing foo project:\\n',"
+        + "  show_description = False,"
+        + "  compact = False\n"
+        + ")");
+    ProcessedChange change = Iterables.getOnlyElement(destination.processed);
+    assertThat(change.getChangesSummary())
+        .isEqualTo(""
+            + "Importing foo project:\n"
+            + "--\n"
+            + "2 by Foo Baz <foo@baz.com>\n"
+            + "--\n"
+            + "1 by Foo Bar <foo@bar.com>\n");
     assertThat(change.getAuthor()).isEqualTo(DEFAULT_AUTHOR);
   }
 


### PR DESCRIPTION
I believe this will add the ability to disable showing the commit message when using `metadata.squash_notes`.

This can be tested by now providing `show_description = False` with `metadata.squash_notes`. This should remove the message in all cases, including compact and non compact notes.

Docs updated as a part of this and tests updated.

Sorry for the fun fiasco, rebase and squashed, and right email address for CLA :)