### PR TITLE
Fix formatting error in metadata.add_header docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1959,7 +1959,8 @@ COPYBARA CHANGE FOR https://github.com/myproject/foo/pull/1234
 Example description for
 documentation
 
-GIT_URL=http://foo.com/1234```
+GIT_URL=http://foo.com/1234
+```
 
 Assuming the PR number is 1234. But any change without that label will not be transformed.
 


### PR DESCRIPTION
"\`\`\`"  at the end of a line does not close a code block. "\`\`\`python" also does not close a code block, so the error was not obvious.