### PR TITLE
Use bazel docker image for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8 AS build
-
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
-  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-
-RUN apt-get update \
-  && apt-get install -y bazel \
-  && rm -rf /var/lib/apt/lists/*
+FROM l.gcr.io/google/bazel:latest AS build
 
 WORKDIR /usr/src/copybara
 


### PR DESCRIPTION
Instead of using the jdk image and then installing bazel, it probably makes sense to use the bazel provided image directly.