### PR TITLE
Extend raw Subject instead of supplying type parameters.

### DIFF
--- a/java/com/google/copybara/testing/FileSubjects.java
+++ b/java/com/google/copybara/testing/FileSubjects.java
@@ -58,7 +58,7 @@ public class FileSubjects {
     return assertAbout(PATH_SUBJECT_FACTORY).that(path);
   }
 
-  public static class PathSubject extends Subject<PathSubject, Path> {
+  public static class PathSubject extends Subject {
 
     private final Path actual;
     private final Set<Path> whitelistedPaths = new HashSet<>();

--- a/java/com/google/copybara/util/console/testing/LogSubjects.java
+++ b/java/com/google/copybara/util/console/testing/LogSubjects.java
@@ -40,7 +40,7 @@ public class LogSubjects {
 
   private LogSubjects() {}
 
-  public static class LogSubject extends Subject<LogSubject, TestingConsole> {
+  public static class LogSubject extends Subject {
 
     private final ArrayDeque<Message> messages;
 


### PR DESCRIPTION
The type parameters are being removed from Subject.

This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).