### PR TITLE
Always set locale to english when running git

### DIFF
--- a/java/com/google/copybara/git/GitEnvironment.java
+++ b/java/com/google/copybara/git/GitEnvironment.java
@@ -37,6 +37,11 @@ public class GitEnvironment {
 
   public ImmutableMap<String, String> getEnvironment() {
     Map<String, String> env = Maps.newHashMap(environment);
+
+    // Explicitly set output language to english so parsing of git's output
+    // succeeds independently of users default locale.
+    env.put("LANG", "en_US.UTF-8");
+
     if (noGitPrompt) {
       env.put("GIT_TERMINAL_PROMPT", "0");
     }

--- a/javatests/com/google/copybara/git/GitEnvironmentTest.java
+++ b/javatests/com/google/copybara/git/GitEnvironmentTest.java
@@ -28,12 +28,30 @@ import org.junit.runners.JUnit4;
 public class GitEnvironmentTest {
 
   private static final Map<String, String> environment =
-      ImmutableMap.<String, String>builder().put("FOO", "123").put("BAR", "456").build();
+      ImmutableMap.<String, String>builder()
+          .put("FOO", "123")
+          .put("BAR", "456")
+          .put("LANG", "en_US.UTF-8")
+          .build();
 
   @Test
   public void testEnvironmentReturned() {
     assertThat(new GitEnvironment(environment, /*noGitPrompt*/ false).getEnvironment())
         .containsExactlyEntriesIn(environment);
+  }
+
+  @Test
+  public void testLangIsSetToEnUsUtf8() {
+    assertThat(new GitEnvironment(ImmutableMap.of(), /*noGitPrompt*/ true).getEnvironment())
+        .containsEntry("LANG", "en_US.UTF-8");
+  }
+
+  @Test
+  public void testLangIsOverridenToEnUsUtf8() {
+    assertThat(
+            new GitEnvironment(ImmutableMap.of("LANG", "de_DE.UTF-8"), /*noGitPrompt*/ true)
+                .getEnvironment())
+        .containsEntry("LANG", "en_US.UTF-8");
   }
 
   @Test


### PR DESCRIPTION
Copybara runs may fail if users use a different locale than english
because we try to parse git's language dependent output.
This change fixes this bug by forcing git's output language always to be english.