### PR TITLE
Add format module and implement buildifier transform to format Bazel/Starlark files

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,6 +52,8 @@
   - [folder](#folder)
     - [folder.destination](#folder.destination)
     - [folder.origin](#folder.origin)
+  - [format](#format)
+    - [format.buildifier](#format.buildifier)
   - [gerritapi.AccountInfo](#gerritapi.accountinfo)
   - [gerritapi.ApprovalInfo](#gerritapi.approvalinfo)
   - [gerritapi.ChangeInfo](#gerritapi.changeinfo)
@@ -1333,6 +1335,30 @@ Name | Type | Description
 <nobr>`--folder-origin-author`</nobr> | *string* | Deprecated. Please use '--force-author'. Author of the change being migrated from folder.origin()
 <nobr>`--folder-origin-ignore-invalid-symlinks`</nobr> | *boolean* | If an invalid symlink is found, ignore it instead of failing
 <nobr>`--folder-origin-message`</nobr> | *string* | Deprecated. Please use '--force-message'. Message of the change being migrated from folder.origin()
+
+
+
+## format
+
+Set of functions to format files
+
+<a id="format.buildifier" aria-hidden="true"></a>
+### format.buildifier
+
+Runs <a href="https://github.com/bazelbuild/buildtools/tree/master/buildifier">buildifier</a>, a tool for formatting bazel BUILD and .bzl files with a standard convention.
+
+`transformation format.buildifier(files, mode="fix", lint="off", warnings=None, type="auto")`
+
+
+#### Parameters:
+
+Parameter | Description
+--------- | -----------
+files | `glob`<br><p>A glob of files to format, relative to the workdir (for example `glob(["**/BUILD", "**/BUILD.bazel", "**/*.bzl"])`).</p>
+mode | `string`<br><p>The formatting mode to pass to buildifier. Valid values are `fix`.</p>
+lint | `string`<br><p>The lint mode to pass to buildifier. Valid values are `off` and `fix`.</p>
+warnings | `object`<br><p>A list of buildifier warnings to enable.</p>
+type | `string`<br><p>The lint mode to pass to buildifier. Valid values are `auto`.</p>
 
 
 

--- a/java/com/google/copybara/ModuleSupplier.java
+++ b/java/com/google/copybara/ModuleSupplier.java
@@ -37,6 +37,7 @@ import com.google.copybara.hg.HgModule;
 import com.google.copybara.hg.HgOptions;
 import com.google.copybara.hg.HgOriginOptions;
 import com.google.copybara.transform.debug.DebugOptions;
+import com.google.copybara.transform.format.FormatModule;
 import com.google.copybara.transform.metadata.MetadataModule;
 import com.google.copybara.transform.patch.PatchModule;
 import com.google.copybara.transform.patch.PatchingOptions;
@@ -84,6 +85,7 @@ public class ModuleSupplier {
             options.get(FolderOriginOptions.class),
             options.get(FolderDestinationOptions.class),
             general),
+        new FormatModule(),
         new PatchModule(options.get(PatchingOptions.class)),
         new MetadataModule(),
         new Authoring.Module());

--- a/java/com/google/copybara/transform/BUILD
+++ b/java/com/google/copybara/transform/BUILD
@@ -39,5 +39,6 @@ java_library(
         "//third_party:jsr305",
         "//third_party:re2j",
         "//third_party:skylark-lang",
+        "//third_party/bazel:shell",
     ],
 )

--- a/java/com/google/copybara/transform/format/BuildifierTransform.java
+++ b/java/com/google/copybara/transform/format/BuildifierTransform.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.copybara.transform.format;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.copybara.TransformWork;
+import com.google.copybara.Transformation;
+import com.google.copybara.exception.ValidationException;
+import com.google.copybara.shell.Command;
+import com.google.copybara.shell.CommandException;
+import com.google.copybara.transform.ExplicitReversal;
+import com.google.copybara.transform.IntentionalNoop;
+import com.google.copybara.treestate.TreeState.FileState;
+import com.google.copybara.util.BadExitStatusWithOutputException;
+import com.google.copybara.util.CommandRunner;
+import com.google.copybara.util.Glob;
+import java.io.IOException;
+
+/**
+ * Transformation for running <a
+ * href="https://github.com/bazelbuild/buildtools/tree/master/buildifier">buildifier</a> on source
+ * files.
+ */
+public class BuildifierTransform implements Transformation {
+  private static final Joiner JOINER = Joiner.on(",");
+
+  private final Glob glob;
+
+  private final String mode;
+  private final String lint;
+  private final ImmutableList<String> warnings;
+  private final String type;
+
+  BuildifierTransform(
+      Glob glob, String mode, String lint, ImmutableList<String> warnings, String type) {
+    this.glob = checkNotNull(glob);
+
+    this.mode = checkNotNull(mode);
+    this.lint = checkNotNull(lint);
+    this.warnings = checkNotNull(warnings);
+    this.type = checkNotNull(type);
+  }
+
+  @Override
+  public String describe() {
+    return "format.buildifier";
+  }
+
+  @Override
+  public void transform(TransformWork work) throws IOException, ValidationException {
+    Iterable<FileState> files = work.getTreeState().find(glob.relativeTo(work.getCheckoutDir()));
+    transform(files, false);
+    work.getTreeState().notifyModify(files);
+  }
+
+  private void transform(Iterable<FileState> files, boolean verbose) throws IOException {
+    ImmutableList.Builder<String> params = ImmutableList.builder();
+
+    // TODO(yannic): Make binary configurable.
+    params.add("buildifier");
+
+    params.add(String.format("--mode=%s", mode));
+    params.add(String.format("--lint=%s", lint));
+    if (warnings.size() > 0) {
+      params.add(String.format("--warnings=%s", JOINER.join(warnings)));
+    }
+    params.add(String.format("--type=%s", type));
+
+    for (FileState file : files) {
+      params.add(file.getPath().toString());
+    }
+
+    Command command = new Command(params.build().toArray(new String[0]));
+    try {
+      new CommandRunner(command).withVerbose(verbose).execute();
+    } catch (BadExitStatusWithOutputException e) {
+      throw new IOException(
+          String.format(
+              "Error executing 'buildifier': %s. Stderr: \n%s",
+              e.getMessage(), e.getOutput().getStderr()),
+          e);
+    } catch (CommandException e) {
+      throw new IOException("Error executing 'buildifier'", e);
+    }
+  }
+
+  @Override
+  public Transformation reverse() {
+    return new ExplicitReversal(IntentionalNoop.INSTANCE, this);
+  }
+}

--- a/java/com/google/copybara/transform/format/FormatModule.java
+++ b/java/com/google/copybara/transform/format/FormatModule.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.copybara.transform.format;
+
+import com.google.common.collect.ImmutableList;
+import com.google.copybara.Transformation;
+import com.google.copybara.config.SkylarkUtil;
+import com.google.copybara.util.Glob;
+import com.google.devtools.build.lib.skylarkinterface.Param;
+import com.google.devtools.build.lib.skylarkinterface.SkylarkCallable;
+import com.google.devtools.build.lib.skylarkinterface.SkylarkModule;
+import com.google.devtools.build.lib.skylarkinterface.SkylarkModuleCategory;
+import com.google.devtools.build.lib.syntax.EvalException;
+import com.google.devtools.build.lib.syntax.NoneType;
+import com.google.devtools.build.lib.syntax.Sequence;
+import com.google.devtools.build.lib.syntax.StarlarkValue;
+
+/** Main module that groups all the transforms formatting files. */
+@SkylarkModule(
+    name = "format",
+    namespace = true,
+    doc = "Set of functions to format files",
+    category = SkylarkModuleCategory.BUILTIN)
+public final class FormatModule implements StarlarkValue {
+  @SuppressWarnings("unused")
+  @SkylarkCallable(
+      name = "buildifier",
+      doc =
+          "Runs <a href=\"https://github.com/bazelbuild/buildtools/tree/master/buildifier\">"
+              + "buildifier</a>, a tool for formatting bazel BUILD and .bzl files with a standard "
+              + "convention.",
+      parameters = {
+        @Param(
+            name = "files",
+            type = Glob.class,
+            named = true,
+            doc =
+                "A glob of files to format, relative to the workdir "
+                    + "(for example `glob([\"**/BUILD\", \"**/BUILD.bazel\", \"**/*.bzl\"])`)."),
+        @Param(
+            name = "mode",
+            type = String.class,
+            named = true,
+            defaultValue = "\"fix\"",
+            // TODO(yannic): Implement mode={check,diff}.
+            doc = "The formatting mode to pass to buildifier. Valid values are `fix`."),
+        @Param(
+            name = "lint",
+            type = String.class,
+            named = true,
+            defaultValue = "\"off\"",
+            // TODO(yannic): Implement lint=warn.
+            doc = "The lint mode to pass to buildifier. Valid values are `off` and `fix`."),
+        @Param(
+            name = "warnings",
+            named = true,
+            defaultValue = "None",
+            noneable = true,
+            doc = "A list of buildifier warnings to enable."),
+        @Param(
+            name = "type",
+            type = String.class,
+            named = true,
+            defaultValue = "\"auto\"",
+            // TODO(yannic): Implement type={build,bzl,workspace,default}.
+            doc = "The lint mode to pass to buildifier. Valid values are `auto`."),
+        // TODO(yannic): Add support for custom tables.
+      })
+  public Transformation buildifier(
+      Glob files, String mode, String lint, Object warningsValue, String type)
+      throws EvalException {
+    // TODO(yannic): Validate the combination of parameters makes sense.
+    ImmutableList.Builder<String> warnings = ImmutableList.builder();
+    if (null == warningsValue || warningsValue instanceof NoneType) {
+      // No warnings to add.
+    } else if (warningsValue instanceof String) {
+      if (!"all".equals(warningsValue)) {
+        throw new EvalException(
+            null, "Only value 'all' allowed if string is passed as parameter 'warnings'");
+      }
+      warnings.add("all");
+    } else if (warningsValue instanceof Sequence) {
+      warnings.addAll(SkylarkUtil.convertStringList(warningsValue, "warnings"));
+    } else {
+      throw new EvalException(
+          null,
+          "expected value of type 'string, sequence of strings, or NoneType' for parameter "
+              + "'warnings', for call to method buildifier(files, mode = \"fix\", "
+              + "lint = \"off\", warnings = None) of 'format (a language module)'");
+    }
+    return new BuildifierTransform(files, mode, lint, warnings.build(), type);
+  }
+}


### PR DESCRIPTION
This PR adds a new transformation that runs [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) during import/export.

Related: #98

Note: This is still WIP (name of binary hardcoded, no tests, ...). I would appreciate an early high-level review to make sure the overall design of this is good, though.