### PR TITLE
feat(docs): add archlinux aur installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ you need:
 	  * `bazel build //java/com/google/copybara:copybara_deploy.jar` to create a executable uberjar.
   * Tests: `bazel test //...` if you want to ensure you are not using a broken version.
 
+### System packages
+
+These packages can be installed using the appropriate package manager for your
+system.
+
+#### Arch Linux
+
+  * [`aur/copybara-git`][install/archlinux/aur-git]
+
+[install/archlinux/aur-git]: https://aur.archlinux.org/packages/copybara-git "Copybara on the AUR"
+
 ### Using Intellij with Bazel plugin
 
 If you use Intellij and the Bazel plugin, use this project configuration:


### PR DESCRIPTION
A package tracking `HEAD` is available on the AUR. This patch adds a
reference to that package. It also sets up the framework for documenting
system packages in the README, as a section for this did not exist.

---

I maintain this over at https://github.com/sudoforge/pkgbuilds/tree/master/copybara-git. The way that `*-git` packages work in Arch means that anybody who builds this package will always grab the latest version of the repository; although I will periodically bump the `pkgver` variable (denoting the "package version") in order to "notify" downstream users' tooling that a new version is out.