### PR TITLE
Removes the full stop after bazel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ you need:
   * Clone the copybara source locally:
       * `git clone https://github.com/google/copybara.git`
   * Build:
-      * `bazel build //java/com/google/copybara`.
+      * `bazel build //java/com/google/copybara`
 	  * `bazel build //java/com/google/copybara:copybara_deploy.jar` to create an executable uberjar.
   * Tests: `bazel test //...` if you want to ensure you are not using a broken version.
 


### PR DESCRIPTION
Having this full stop might mislead people who are new to bazel to think of it as part of the bazel command.

For example: while following the README.md, I ran `bazel build //java/com/google/copybara .` instead of `bazel build //java/com/google/copybara`

```
$ bazel build //java/com/google/copybara .
Starting local Bazel server and connecting to it...
ERROR: Skipping '.': Bad target pattern '.': package name component contains only '.' characters
ERROR: Bad target pattern '.': package name component contains only '.' characters
INFO: Elapsed time: 9.620s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
```

Hence a small contribution to avoid confusion.