### PR TITLE
feat: use macros for defining external repositories

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-workspace(name = "com_github_google_copybara")
-
-load("//:repositories.bzl", "copybara_repositories")
-
-copybara_repositories()
-
-load("//:repositories.maven.bzl", "copybara_maven_repositories")
-
-copybara_maven_repositories()
-
-load("//:repositories.go.bzl", "copybara_go_repositories")
-
-copybara_go_repositories()

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ you need:
       * `git clone https://github.com/google/copybara.git`
   * Build:
       * `bazel build //java/com/google/copybara`.
-	  * `bazel build //java/com/google/copybara:copybara_deploy.jar` to create an executable uberjar.
+      * `bazel build //java/com/google/copybara:copybara_deploy.jar` to create an executable uberjar.
   * Tests: `bazel test //...` if you want to ensure you are not using a broken version.
 
 ### System packages
@@ -109,6 +109,39 @@ targets:
 
 Note that configuration files can be stored in any place, even in a local folder. We recommend to
 use a VCS (like git) to store them; treat them as source code.
+
+### Building Copybara in an external Bazel workspace
+
+There are convenience macros defined for all of Copybara's dependencies. Add the
+following code to your `WORKSPACE` file, replacing `{{ sha256sum }}` and
+`{{ commit }}` as necessary.
+
+```
+http_archive(
+  name = "com_github_google_copybara",
+  sha256 = "{{ sha256sum }}"
+  strip_prefix = "copybara-{{ commit }}",
+  url = "https://github.com/google/copybara/archive/{{ commit }}",
+)
+
+load("@com_github_google_copybara//:repositories.bzl", "copybara_repositories")
+
+copybara_repositories()
+
+load("@com_github_google_copybara//:repositories.maven.bzl", "copybara_maven_repositories")
+
+copybara_maven_repositories()
+
+load("@com_github_google_copybara//:repositories.go.bzl", "copybara_go_repositories")
+
+copybara_go_repositories()
+```
+
+You can then build and run the Copybara tool from within your workspace:
+
+```
+bazel run @com_github_google_copybara//java/com/google/copybara -- <args...>
+```
 
 ### Using Docker to build and run Copybara
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,154 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("//third_party:bazel.bzl", "bazel_sha256", "bazel_version")
+load("//third_party:bazel_buildtools.bzl", "buildtools_sha256", "buildtools_version")
+load("//third_party:bazel_skylib.bzl", "skylib_sha256", "skylib_version")
+
+def copybara_repositories():
+    RULES_JVM_EXTERNAL_TAG = "3.0"
+
+    RULES_JVM_EXTERNAL_SHA = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a"
+
+    maybe(
+        http_archive,
+        name = "rules_jvm_external",
+        sha256 = RULES_JVM_EXTERNAL_SHA,
+        strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+        url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "io_bazel",
+        sha256 = bazel_sha256,
+        strip_prefix = "bazel-" + bazel_version,
+        url = "https://github.com/bazelbuild/bazel/archive/" + bazel_version + ".zip",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    # Buildifier and friends:
+    maybe(
+        http_archive,
+        name = "buildtools",
+        sha256 = buildtools_sha256,
+        strip_prefix = "buildtools-" + buildtools_version,
+        url = "https://github.com/bazelbuild/buildtools/archive/" + buildtools_version + ".zip",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    # Additional bazel rules:
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = skylib_sha256,
+        strip_prefix = "bazel-skylib-" + skylib_version,
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/" + skylib_version + ".zip",
+    )
+
+    EXPORT_WORKSPACE_IN_BUILD_FILE = [
+        "test -f BUILD && chmod u+w BUILD || true",
+        "echo >> BUILD",
+        "echo 'exports_files([\"WORKSPACE\"], visibility = [\"//visibility:public\"])' >> BUILD",
+    ]
+
+    EXPORT_WORKSPACE_IN_BUILD_FILE_WIN = [
+        "Add-Content -Path BUILD -Value \"`nexports_files([`\"WORKSPACE`\"], visibility = [`\"//visibility:public`\"])`n\" -Force",
+    ]
+
+    # Stuff used by Bazel Starlark syntax package transitively:
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "com_google_protobuf",
+        patch_args = ["-p1"],
+        patches = ["@io_bazel//third_party/protobuf:3.13.0.patch"],
+        patch_cmds = EXPORT_WORKSPACE_IN_BUILD_FILE,
+        patch_cmds_win = EXPORT_WORKSPACE_IN_BUILD_FILE_WIN,
+        sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+        strip_prefix = "protobuf-3.13.0",
+        urls = [
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
+        ],
+    )
+
+    # Stuff used by Buildifier transitively:
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "io_bazel_rules_go",
+        sha256 = "b27e55d2dcc9e6020e17614ae6e0374818a3e3ce6f2024036e688ada24110444",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.21.0/rules_go-v0.21.0.tar.gz",
+        ],
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "rules_pkg",
+        sha256 = "5bdc04987af79bd27bc5b00fe30f59a858f77ffa0bd2d8143d5b31ad8b1bd71c",
+        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.0/rules_pkg-0.2.0.tar.gz",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "rules_java",
+        sha256 = "52423cb07384572ab60ef1132b0c7ded3a25c421036176c0273873ec82f5d2b2",
+        url = "https://github.com/bazelbuild/rules_java/releases/download/0.1.0/rules_java-0.1.0.tar.gz",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "f7402f11691d657161f871e11968a984e5b48b023321935f5a55d7e56cf4758a",
+        strip_prefix = "rules_python-9d68f24659e8ce8b736590ba1e4418af06ec2552",
+        url = "https://github.com/bazelbuild/rules_python/archive/9d68f24659e8ce8b736590ba1e4418af06ec2552.zip",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "rules_cc",
+        sha256 = "faa25a149f46077e7eca2637744f494e53a29fe3814bfe240a2ce37115f6e04d",
+        strip_prefix = "rules_cc-ea5c5422a6b9e79e6432de3b2b29bbd84eb41081",
+        url = "https://github.com/bazelbuild/rules_cc/archive/ea5c5422a6b9e79e6432de3b2b29bbd84eb41081.zip",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "rules_proto",
+        sha256 = "7d05492099a4359a6006d1b89284d34b76390c3b67d08e30840299b045838e2d",
+        strip_prefix = "rules_proto-9cd4f8f1ede19d81c6d48910429fe96776e567b1",
+        url = "https://github.com/bazelbuild/rules_proto/archive/9cd4f8f1ede19d81c6d48910429fe96776e567b1.zip",
+    )
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        http_archive,
+        name = "bazel_gazelle",
+        sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
+        ],
+    )

--- a/repositories.go.bzl
+++ b/repositories.go.bzl
@@ -1,0 +1,33 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+def copybara_go_repositories():
+    go_rules_dependencies()
+
+    go_register_toolchains()
+
+    gazelle_dependencies()
+
+    # LICENSE: The Apache Software License, Version 2.0
+    maybe(
+        go_repository,
+        name = "skylark_syntax",
+        importpath = "go.starlark.net",
+        sum = "h1:Qoe+9POtDT51UBQ8XEnS9QKeHDQzEl2QRh3eok9R4aw=",
+        version = "v0.0.0-20200203144150-6677ee5c7211",
+    )

--- a/repositories.maven.bzl
+++ b/repositories.maven.bzl
@@ -1,0 +1,52 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_jvm_external//:defs.bzl", "DEFAULT_REPOSITORY_NAME", "maven_install")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def copybara_maven_repositories():
+    maybe(
+      maven_install,
+      name = DEFAULT_REPOSITORY_NAME,
+      artifacts = [
+          "com.beust:jcommander:1.48",
+          "com.google.auto.value:auto-value-annotations:1.6.3",
+          "com.google.auto.value:auto-value:1.6.3",
+          "com.google.auto:auto-common:0.10",
+          "com.google.code.findbugs:jsr305:3.0.2",
+          "com.google.code.gson:gson:jar:2.8.5",
+          "com.google.flogger:flogger-system-backend:0.3.1",
+          "com.google.flogger:flogger:0.3.1",
+          "com.google.guava:failureaccess:1.0.1",
+          "com.google.guava:guava-testlib:27.1-jre",
+          "com.google.guava:guava:27.1-jre",
+          "com.google.http-client:google-http-client-gson:jar:1.27.0",
+          "com.google.http-client:google-http-client-test:jar:1.27.0",
+          "com.google.http-client:google-http-client:jar:1.27.0",
+          "com.google.jimfs:jimfs:1.1",
+          "com.google.re2j:re2j:1.2",
+          "com.google.truth:truth:0.45",
+          "com.googlecode.java-diff-utils:diffutils:1.3.0",
+          "commons-codec:commons-codec:jar:1.11",
+          "junit:junit:4.13",
+          "net.bytebuddy:byte-buddy-agent:1.9.10",
+          "net.bytebuddy:byte-buddy:1.9.10",
+          "org.mockito:mockito-core:2.28.2",
+          "org.objenesis:objenesis:1.0",
+      ],
+      repositories = [
+          "https://maven.google.com",
+          "https://repo1.maven.org/maven2",
+      ],
+    )


### PR DESCRIPTION
```
This patch adds macros that wrap around this workspace's external
dependencies:

  - `//:repositories.bzl%copybara_repositories`
  - `//:repositories.go.bzl%copybara_go_repositories`
  - `//:repositories.maven.bzl%copybara_maven_repositories`

The primary motivation for this is to enable easier loading of copybara
from within external repositories. Prior to this patch, those external
repositories would need to re-define each and every dependency listed in
this repository's WORKSPACE file. With this patch, those external
repositories need only to load and call the macros (shown above).

An empty BUILD file is also added in this patch as it is necessary in
order to refer to the files in the workspace root.

closes #73
```