### PR TITLE
Hg merge fix

### DIFF
--- a/java/com/google/copybara/hg/HgOrigin.java
+++ b/java/com/google/copybara/hg/HgOrigin.java
@@ -160,8 +160,12 @@ public class HgOrigin implements Origin<HgRevision> {
     @Override
     public ChangesResponse<HgRevision> changes(@Nullable HgRevision fromRef, HgRevision toRef)
       throws RepoException {
-      String refRange = String.format("%s::%s",
-          fromRef == null ? "" : fromRef.getGlobalId(), toRef.getGlobalId());
+      String fromRefExpression = fromRef == null ? "null" : fromRef.getGlobalId();
+      // The "<from>::<to>" part is to filter out unrelated history. The "only()" bit is
+      // so we include commits merged in from a side branch.
+      String refRange =
+          String.format(
+              "only(%s::%s, %s)", fromRefExpression, toRef.getGlobalId(), fromRefExpression);
 
       try {
         ChangeReader reader = changeReaderBuilder().build();

--- a/javatests/com/google/copybara/WorkflowTest.java
+++ b/javatests/com/google/copybara/WorkflowTest.java
@@ -140,6 +140,7 @@ public class WorkflowTest {
   @Before
   public void setup() throws Exception {
     options = new OptionsBuilder();
+    options.setOutputRootToTmpDir();
     authoring = "authoring.overwrite('" + DEFAULT_AUTHOR + "')";
     includeReleaseNotes = false;
     workdir = Files.createTempDirectory("workdir");
@@ -1932,7 +1933,6 @@ public class WorkflowTest {
     GitRepository origin = GitRepository.newRepo(/*verbose*/ true, originPath, getGitEnv()).init();
     String primaryBranch = origin.getPrimaryBranch();
 
-    options.setOutputRootToTmpDir();
     String config =
         "def after_all(ctx):\n"
         + "  ctx.destination.message('after_all '"
@@ -1984,7 +1984,6 @@ public class WorkflowTest {
     GitRepository origin = GitRepository.newRepo(/*verbose*/ true, originPath, getGitEnv()).init();
     String primaryBranch = origin.getPrimaryBranch();
 
-    options.setOutputRootToTmpDir();
     String config = "core.workflow(\n"
         + "    name = 'default',\n"
         + String.format("    origin = git.origin( url = 'file://%s', ref = '%s'),\n",
@@ -2030,7 +2029,6 @@ public class WorkflowTest {
     GitRepository origin = GitRepository.newRepo(/*verbose*/ true, originPath, getGitEnv()).init();
     String primaryBranch = origin.getPrimaryBranch();
 
-    options.setOutputRootToTmpDir();
     String config = "core.workflow(\n"
         + "    name = 'default',\n"
         + String.format("    origin = git.origin( url = 'file://%s', ref = '%s'),\n",
@@ -2116,8 +2114,6 @@ public class WorkflowTest {
 
     GitRepository origin = GitRepository.newRepo(/*verbose*/ true, originPath, getGitEnv()).init();
     String primaryBranch = origin.getPrimaryBranch();
-
-    options.setOutputRootToTmpDir();
 
     String config = "core.workflow(\n"
         + "    name = 'default',\n"
@@ -3395,7 +3391,6 @@ public class WorkflowTest {
     GitRepository origin = GitRepository.newRepo(/*verbose*/ true, originPath, getGitEnv()).init();
     String primaryBranch = origin.getPrimaryBranch();
 
-    options.setOutputRootToTmpDir();
     options.setForce(false);
     options.workflowOptions.initHistory = true;
 

--- a/javatests/com/google/copybara/hg/HgOriginTest.java
+++ b/javatests/com/google/copybara/hg/HgOriginTest.java
@@ -257,19 +257,19 @@ public class HgOriginTest {
   public void testChanges() throws Exception {
     ZonedDateTime beforeTime = ZonedDateTime.now(ZoneId.systemDefault()).minusSeconds(1);
     String author = "Copy Bara <copy@bara.com>";
+    singleFileCommit(author, "zero", "foo.txt", "zero");
     singleFileCommit(author, "one", "foo.txt", "one");
-    singleFileCommit(author, "two", "foo.txt", "two");
-    Path filePath = singleFileCommit(author, "three", "foo.txt", "three");
+    Path filePath = singleFileCommit(author, "two", "foo.txt", "two");
 
-    assertThat(Files.readAllBytes(filePath)).isEqualTo("three".getBytes(UTF_8));
+    assertThat(Files.readAllBytes(filePath)).isEqualTo("two".getBytes(UTF_8));
 
     ImmutableList<Change<HgRevision>> changes =
         newReader().changes(origin.resolve("1"), origin.resolve("tip")).getChanges();
 
     assertThat(changes).hasSize(2);
 
-    assertThat(changes.get(0).getMessage()).isEqualTo("two");
-    assertThat(changes.get(1).getMessage()).isEqualTo("three");
+    assertThat(changes.get(0).getMessage()).isEqualTo("one");
+    assertThat(changes.get(1).getMessage()).isEqualTo("two");
 
     for (Change<HgRevision> change : changes) {
       assertThat(change.getAuthor().getEmail()).isEqualTo("copy@bara.com");
@@ -292,16 +292,16 @@ public class HgOriginTest {
   @Test
   public void testChangesNoFromRef() throws Exception {
     String author = "Copy Bara <copy@bara.com>";
+    singleFileCommit(author, "zero", "foo.txt", "zero");
     singleFileCommit(author, "one", "foo.txt", "one");
     singleFileCommit(author, "two", "foo.txt", "two");
-    singleFileCommit(author, "three", "foo.txt", "three");
 
     ImmutableList<Change<HgRevision>> changes =
         newReader().changes(null, origin.resolve("1")).getChanges();
 
     assertThat(changes).hasSize(2);
-    assertThat(changes.get(0).getMessage()).isEqualTo("one");
-    assertThat(changes.get(1).getMessage()).isEqualTo("two");
+    assertThat(changes.get(0).getMessage()).isEqualTo("zero");
+    assertThat(changes.get(1).getMessage()).isEqualTo("one");
   }
 
   @Test
@@ -339,8 +339,8 @@ public class HgOriginTest {
   @Test
   public void testChangesToIsAncestor() throws Exception {
     String author = "Copy Bara <copy@bara.com>";
+    singleFileCommit(author, "zero", "foo.txt", "zero");
     singleFileCommit(author, "one", "foo.txt", "one");
-    singleFileCommit(author, "two", "foo.txt", "two");
 
     ChangesResponse<HgRevision> changes =
         newReader().changes(origin.resolve("tip"), origin.resolve("0"));
@@ -361,7 +361,7 @@ public class HgOriginTest {
   @Test
   public void testChange() throws Exception {
     String author = "Copy Bara <copy@bara.com>";
-    singleFileCommit(author, "one", "foo.txt", "one");
+    singleFileCommit(author, "zero", "foo.txt", "zero");
 
     Change<HgRevision> change = newReader().change(origin.resolve("tip"));
 
@@ -370,7 +370,7 @@ public class HgOriginTest {
 
     assertThat(change.getChangeFiles()).containsExactly("foo.txt");
 
-    assertThat(change.getMessage()).isEqualTo("one");
+    assertThat(change.getMessage()).isEqualTo("zero");
   }
 
   @Test
@@ -383,10 +383,10 @@ public class HgOriginTest {
   @Test
   public void testVisit() throws Exception {
     String author = "Copy Bara <copy@bara.com>";
+    singleFileCommit(author, "zero", "foo.txt", "zero");
     singleFileCommit(author, "one", "foo.txt", "one");
     singleFileCommit(author, "two", "foo.txt", "two");
     singleFileCommit(author, "three", "foo.txt", "three");
-    singleFileCommit(author, "four", "foo.txt", "four");
 
     List<Change<?>> visited = new ArrayList<>();
 
@@ -395,22 +395,22 @@ public class HgOriginTest {
             origin.resolve("tip"),
             input -> {
               visited.add(input);
-              return input.firstLineMessage().equals("three")
+              return input.firstLineMessage().equals("two")
                   ? VisitResult.TERMINATE
                   : VisitResult.CONTINUE;
             });
 
     assertThat(visited).hasSize(2);
-    assertThat(visited.get(0).firstLineMessage()).isEqualTo("four");
-    assertThat(visited.get(1).firstLineMessage()).isEqualTo("three");
+    assertThat(visited.get(0).firstLineMessage()).isEqualTo("three");
+    assertThat(visited.get(1).firstLineMessage()).isEqualTo("two");
   }
 
   @Test
   public void testVisitOutsideRoot() throws Exception {
     String author = "Copy Bara <copy@bara.com>";
-    singleFileCommit(author, "one", "foo/foo.txt", "one");
-    singleFileCommit(author, "two", "bar/foo.txt", "two");
-    singleFileCommit(author, "three", "foo/foo.txt", "three");
+    singleFileCommit(author, "zero", "foo/foo.txt", "zero");
+    singleFileCommit(author, "one", "bar/foo.txt", "one");
+    singleFileCommit(author, "two", "foo/foo.txt", "two");
 
     originFiles = Glob.createGlob(ImmutableList.of("bar/**"));
 
@@ -423,7 +423,7 @@ public class HgOriginTest {
               return VisitResult.CONTINUE;
             });
     assertThat(visited).hasSize(1);
-    assertThat(visited.get(0).firstLineMessage()).isEqualTo("two");
+    assertThat(visited.get(0).firstLineMessage()).isEqualTo("one");
   }
 
   @Test

--- a/javatests/com/google/copybara/hg/HgOriginTest.java
+++ b/javatests/com/google/copybara/hg/HgOriginTest.java
@@ -264,7 +264,7 @@ public class HgOriginTest {
     assertThat(Files.readAllBytes(filePath)).isEqualTo("two".getBytes(UTF_8));
 
     ImmutableList<Change<HgRevision>> changes =
-        newReader().changes(origin.resolve("1"), origin.resolve("tip")).getChanges();
+        newReader().changes(origin.resolve("0"), origin.resolve("tip")).getChanges();
 
     assertThat(changes).hasSize(2);
 


### PR DESCRIPTION
This replaces #173. Sorry, I didn't realize that temporarily deleting the branch in my repo would close the pull request. The new version does not have the commit that fixed some warnings about raw types (which failed internal tests because Google uses a different version of Truth internally, it seems).