### PR TITLE
make getCurrentBranch compatible with older git

### DIFF
--- a/java/com/google/copybara/git/GitRepository.java
+++ b/java/com/google/copybara/git/GitRepository.java
@@ -2178,6 +2178,6 @@ public class GitRepository {
 
   /** The current branch, if any. */
   public String getCurrentBranch() throws RepoException {
-    return simpleCommand("branch", "--show-current").getStdout().trim();
+    return simpleCommand("rev-parse", "--abbrev-ref", "HEAD").getStdout().trim();
   }
 }

--- a/java/com/google/copybara/git/GitRepository.java
+++ b/java/com/google/copybara/git/GitRepository.java
@@ -2178,6 +2178,9 @@ public class GitRepository {
 
   /** The current branch, if any. */
   public String getCurrentBranch() throws RepoException {
-    return simpleCommand("rev-parse", "--abbrev-ref", "HEAD").getStdout().trim();
+    String rev = simpleCommand("rev-parse", "--abbrev-ref", "HEAD").getStdout().trim();
+    if (rev.equals("HEAD"))
+      return "";
+    return rev;
   }
 }


### PR DESCRIPTION
git branch --show-current is introduced in git 2.22.0, released on 2019-06-07.
Older git versions are still maintained and widely used, including the current Debian stable (buster).

Another benefit is that `rev-parse` is a plumbing command and might have stable output format. Maybe.

Closes #176 