### PR TITLE
docs: minor fix for metadata.replace_message

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3425,6 +3425,7 @@ Will transform the message to:
 
 ```
 COPYBARA CHANGE: Import of 12345
+
 Body from Github Pull Request
 ```
 

--- a/java/com/google/copybara/transform/metadata/MetadataModule.java
+++ b/java/com/google/copybara/transform/metadata/MetadataModule.java
@@ -630,7 +630,7 @@ public class MetadataModule implements StarlarkValue {
       after =
           "Will transform the message to:\n\n"
               + "```\n"
-              + "COPYBARA CHANGE: Import of 12345"
+              + "COPYBARA CHANGE: Import of 12345\n"
               + "\n"
               + "Body from Github Pull Request"
               + "\n"


### PR DESCRIPTION
the example is missing a newline.