### PR TITLE
Allow a custom separator with save_author() and restore_author()

### DIFF
--- a/java/com/google/copybara/transform/metadata/MetadataModule.java
+++ b/java/com/google/copybara/transform/metadata/MetadataModule.java
@@ -214,10 +214,15 @@ public class MetadataModule implements StarlarkValue {
             named = true,
             doc = "The label to use for storing the author",
             defaultValue = "'ORIGINAL_AUTHOR'"),
+        @Param(
+            name = "separator",
+            named = true,
+            doc = "The separator to use between the label and the value",
+            defaultValue = "\"=\""),
       },
       useStarlarkThread = true)
-  public Transformation saveAuthor(String label, StarlarkThread thread) {
-    return new SaveOriginalAuthor(label, thread.getCallerLocation());
+  public Transformation saveAuthor(String label, String separator, StarlarkThread thread) {
+    return new SaveOriginalAuthor(label, separator, thread.getCallerLocation());
   }
 
   static final String MAP_AUTHOR_EXAMPLE_SIMPLE = ""
@@ -500,6 +505,11 @@ public class MetadataModule implements StarlarkValue {
             doc = "The label to use for restoring the author",
             defaultValue = "'ORIGINAL_AUTHOR'"),
         @Param(
+            name = "separator",
+            named = true,
+            doc = "The separator to use between the label and the value",
+            defaultValue = "\"=\""),
+        @Param(
             name = "search_all_changes",
             named = true,
             doc =
@@ -510,8 +520,8 @@ public class MetadataModule implements StarlarkValue {
       },
       useStarlarkThread = true)
   public Transformation restoreAuthor(
-      String label, Boolean searchAllChanges, StarlarkThread thread) {
-    return new RestoreOriginalAuthor(label, searchAllChanges, thread.getCallerLocation());
+      String label, String separator, Boolean searchAllChanges, StarlarkThread thread) {
+    return new RestoreOriginalAuthor(label, separator, searchAllChanges, thread.getCallerLocation());
     }
 
   @SuppressWarnings("unused")

--- a/java/com/google/copybara/transform/metadata/RestoreOriginalAuthor.java
+++ b/java/com/google/copybara/transform/metadata/RestoreOriginalAuthor.java
@@ -36,12 +36,14 @@ import net.starlark.java.syntax.Location;
 public class RestoreOriginalAuthor implements Transformation {
 
   private final String label;
+  private final String separator;
   private final boolean searchAllChanges;
   private final Location location;
 
-  RestoreOriginalAuthor(String label, boolean searchAllChanges,
-      Location location) {
+  RestoreOriginalAuthor(String label, String separator,
+          boolean searchAllChanges, Location location) {
     this.label = label;
+    this.separator = separator;
     this.searchAllChanges = searchAllChanges;
     this.location = Preconditions.checkNotNull(location);
   }
@@ -76,7 +78,7 @@ public class RestoreOriginalAuthor implements Transformation {
 
   @Override
   public Transformation reverse() throws NonReversibleValidationException {
-    return new SaveOriginalAuthor(label, location);
+    return new SaveOriginalAuthor(label, separator, location);
   }
 
   @Override

--- a/java/com/google/copybara/transform/metadata/SaveOriginalAuthor.java
+++ b/java/com/google/copybara/transform/metadata/SaveOriginalAuthor.java
@@ -31,23 +31,26 @@ import net.starlark.java.syntax.Location;
 public class SaveOriginalAuthor implements Transformation {
 
   private final String label;
+  private final String separator;
   private final Location location;
 
-  SaveOriginalAuthor(String label, Location location) {
+  SaveOriginalAuthor(String label, String separator, Location location) {
+
     this.label = Preconditions.checkNotNull(label);
+    this.separator = Preconditions.checkNotNull(separator);
     this.location = Preconditions.checkNotNull(location);
   }
 
   @Override
   public TransformationStatus transform(TransformWork work)
       throws IOException, ValidationException {
-    work.addOrReplaceLabel(label, work.getAuthor().toString(), "=");
+    work.addOrReplaceLabel(label, work.getAuthor().toString(), separator);
     return TransformationStatus.success();
   }
 
   @Override
   public Transformation reverse() throws NonReversibleValidationException {
-    return new RestoreOriginalAuthor(label, /*searchAllChanges=*/false, location);
+    return new RestoreOriginalAuthor(label, separator, /*searchAllChanges=*/false, location);
   }
 
   @Override

--- a/javatests/com/google/copybara/transform/metadata/MetadataModuleTest.java
+++ b/javatests/com/google/copybara/transform/metadata/MetadataModuleTest.java
@@ -607,6 +607,31 @@ public class MetadataModuleTest {
   }
 
   @Test
+  public void testSaveAuthorOtherSeparator() throws Exception {
+    Workflow<?, ?> wf =
+        createWorkflow(WorkflowMode.ITERATIVE, "metadata.save_author(separator=': ')");
+    origin.setAuthor(new Author("keep me", "keep@me.com"))
+        .addSimpleChange(0, "A change");
+    wf.run(workdir, ImmutableList.of());
+    ProcessedChange change = Iterables.getLast(destination.processed);
+    assertThat(change.getChangesSummary()).contains("ORIGINAL_AUTHOR: keep me <keep@me.com>");
+    assertThat(change.getChangesSummary()).doesNotContain("ORIGINAL_AUTHOR=");
+  }
+
+  @Test
+  public void testSaveAuthorOtherLabelAndSeparator() throws Exception {
+    Workflow<?, ?> wf =
+        createWorkflow(WorkflowMode.ITERATIVE, "metadata.save_author('OTHER_LABEL', separator=': ')");
+    origin.setAuthor(new Author("keep me", "keep@me.com"))
+        .addSimpleChange(0, "A change");
+    wf.run(workdir, ImmutableList.of());
+    ProcessedChange change = Iterables.getLast(destination.processed);
+    assertThat(change.getChangesSummary()).contains("OTHER_LABEL: keep me <keep@me.com>");
+    assertThat(change.getChangesSummary()).doesNotContain("ORIGINAL_AUTHOR");
+    assertThat(change.getChangesSummary()).doesNotContain("ORIGINAL_AUTHOR=");
+  }
+
+  @Test
   public void testsSaveReplaceAuthor() throws Exception {
     Workflow<?, ?> wf = createWorkflow(WorkflowMode.ITERATIVE, "metadata.save_author()");
     origin.setAuthor(new Author("keep me", "keep@me.com"))
@@ -661,6 +686,36 @@ public class MetadataModuleTest {
     assertThat(change.getChangesSummary()).doesNotContain("restore@me.com");
     assertThat(change.getChangesSummary()).contains("ORIGINAL_AUTHOR=no no <no@no.com>");
     assertThat(change.getChangesSummary()).doesNotContain("OTHER_LABEL");
+    assertThat(change.getAuthor().toString()).isEqualTo("restore me <restore@me.com>");
+  }
+
+  @Test
+  public void testRestoreAuthorOtherSeparator() throws Exception {
+    Workflow<?, ?> wf =
+        createWorkflow(WorkflowMode.ITERATIVE, "metadata.restore_author(separator=': ')");
+    origin.setAuthor(new Author("remove me", "remove@me.com"))
+        .addSimpleChange(0, "A change\n\n"
+            + "ORIGINAL_AUTHOR: restore me <restore@me.com>\n");
+    wf.run(workdir, ImmutableList.of());
+    ProcessedChange change = Iterables.getLast(destination.processed);
+    assertThat(change.getChangesSummary()).doesNotContain("restore@me.com");
+    assertThat(change.getChangesSummary()).doesNotContain("ORIGINAL_AUTHOR");
+    assertThat(change.getAuthor().toString()).isEqualTo("restore me <restore@me.com>");
+  }
+
+  @Test
+  public void testRestoreAuthorOtherLabelAndSeparator() throws Exception {
+    Workflow<?, ?> wf =
+        createWorkflow(WorkflowMode.ITERATIVE, "metadata.restore_author('OTHER_LABEL', separator=': ')");
+    origin.setAuthor(new Author("remove me", "remove@me.com"))
+        .addSimpleChange(0, "A change\n\n"
+            + "OTHER_LABEL: restore me <restore@me.com>\n"
+            + "ORIGINAL_AUTHOR=no no <no@no.com>\n");
+    wf.run(workdir, ImmutableList.of());
+    ProcessedChange change = Iterables.getLast(destination.processed);
+    assertThat(change.getChangesSummary()).doesNotContain("restore@me.com");
+    assertThat(change.getChangesSummary()).contains("ORIGINAL_AUTHOR=no no <no@no.com>");
+    assertThat(change.getChangesSummary()).doesNotContain("OTHER_LABEL:");
     assertThat(change.getAuthor().toString()).isEqualTo("restore me <restore@me.com>");
   }
 


### PR DESCRIPTION
```
Allow a custom separator with `save_author()` and `restore_author()`

This change adds support for a custom separator on the
`metadata.save_author()` and `metadata.restore_author()` methods, which
is useful to users who want a consistent separator used for all trailers
present in their commit messages.

closes #188
```