### PR TITLE
Add support for options specified in `//:.bazelrc.user`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,12 @@ build --jvmopt='-Dsun.jnu.encoding=UTF-8'
 build --jvmopt='-Dfile.encoding=UTF-8'
 build --test_env='LANG=en_US.UTF-8'
 test --test_env=PATH
+
+################################################################################
+# User bazel configuration
+################################################################################
+
+# Load from the local configuration file, if it exists. This needs to be the
+# *last* statement in the root configuration file, as the local configuration
+# file should be able to overwrite flags from the root configuration.
+try-import %workspace%/.bazelrc.user

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bazel-*
 *.iml
 *.pyc
 .ijwb
+/.bazelrc.user


### PR DESCRIPTION
```
Add support for options specified in `//:.bazelrc.user`

With this change, users can specify options for Bazel in a configuration
file at `//:.bazelrc.user`. The options specified in this file will
be merged with options specified in `//:.bazelrc`. Because this
`//:.bazelrc.user` file is loaded at the end of `//:.bazelrc`, options
specified in the former will override those set in the latter.
```