### PR TITLE
Fix download URL in WORKSPACE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ http_archive(
   name = "com_github_google_copybara",
   sha256 = "{{ sha256sum }}"
   strip_prefix = "copybara-{{ commit }}",
-  url = "https://github.com/google/copybara/archive/{{ commit }}",
+  url = "https://github.com/google/copybara/archive/{{ commit }}.zip",
 )
 
 load("@com_github_google_copybara//:repositories.bzl", "copybara_repositories")


### PR DESCRIPTION
GitHub archive URLs end in ".zip"

```bash
# Current URL
$ curl -I https://github.com/google/copybara/archive/61c4e044f8a5a177a8e2e769fe2c839f74e747dd
HTTP/2 404
...
# After
$ curl -I https://github.com/google/copybara/archive/61c4e044f8a5a177a8e2e769fe2c839f74e747dd.zip
HTTP/2 302
```