### PR TITLE
use full-qualified label for jcommander BUILD file

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -161,5 +161,5 @@ def copybara_repositories():
         urls = [
             "https://github.com/cbeust/jcommander/archive/05254453c0a824f719bd72dac66fa686525752a5.zip",
         ],
-        build_file = "third_party/jcommander.BUILD"
+        build_file = Label("//external/third_party:jcommander.BUILD"),
     )


### PR DESCRIPTION
currently when running `copybara_maven_repositories()` in an external workspace, bazel cannot access `jcommander.BUILD` file, because the directory `external/third_party` is not marked as a package. This PR fixes this by adding `BUILD` file under the said directory and use ful-qualified label.