### PR TITLE
supply list of artifacts separate from the maven_install

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -19,9 +19,9 @@ load("//third_party:bazel_buildtools.bzl", "buildtools_sha256", "buildtools_vers
 load("//third_party:bazel_skylib.bzl", "skylib_sha256", "skylib_version")
 
 def copybara_repositories():
-    RULES_JVM_EXTERNAL_TAG = "3.0"
+    RULES_JVM_EXTERNAL_TAG = "4.2"
 
-    RULES_JVM_EXTERNAL_SHA = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a"
+    RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
 
     maybe(
         http_archive,

--- a/repositories.maven.bzl
+++ b/repositories.maven.bzl
@@ -13,42 +13,46 @@
 # limitations under the License.
 
 load("@rules_jvm_external//:defs.bzl", "DEFAULT_REPOSITORY_NAME", "maven_install")
+load("@rules_jvm_external//:specs.bzl", "maven")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+COPYBARA_MAVEN_ARTIFACTS = [
+    maven.artifact("com.google.auto.value", "auto-value-annotations", "1.9"),
+    maven.artifact("com.google.auto.value", "auto-value", "1.9"),
+    maven.artifact("com.google.auto", "auto-common", "1.2.1"),
+    maven.artifact("com.google.code.findbugs", "jsr305", "3.0.2", neverlink = True),
+    maven.artifact("com.google.code.gson", "gson", "2.8.5"),
+    maven.artifact("com.google.flogger", "flogger-system-backend", "0.7.4"),
+    maven.artifact("com.google.flogger", "flogger", "0.7.4"),
+    maven.artifact("com.google.guava", "failureaccess", "1.0.1"),
+    maven.artifact("com.google.guava", "guava-testlib", "31.1-jre", testonly = True),
+    maven.artifact("com.google.guava", "guava", "31.1-jre"),
+    maven.artifact("com.google.http-client", "google-http-client-gson", "1.27.0"),
+    maven.artifact("com.google.http-client", "google-http-client-test", "1.27.0"),
+    maven.artifact("com.google.http-client", "google-http-client", "1.27.0"),
+    maven.artifact("com.google.jimfs", "jimfs", "1.2"),
+    maven.artifact("com.google.re2j", "re2j", "1.6"),
+    maven.artifact("com.google.testparameterinjector", "test-parameter-injector", "1.8", testonly = True),
+    maven.artifact("com.google.truth", "truth", "1.1.3", testonly = True),
+    maven.artifact("com.google.truth.extensions", "truth-java8-extension", "0.41", testonly = True),
+    maven.artifact("com.googlecode.java-diff-utils", "diffutils", "1.3.0"),
+    maven.artifact("commons-codec", "commons-codec", "1.11"),
+    maven.artifact("junit", "junit", "4.13.2", testonly = True),
+    maven.artifact("net.bytebuddy", "byte-buddy-agent", "1.9.10", testonly = True),
+    maven.artifact("net.bytebuddy", "byte-buddy", "1.9.10", testonly = True),
+    maven.artifact("org.mockito", "mockito-core", "4.5.1", testonly = True),
+    maven.artifact("org.objenesis", "objenesis", "1.0", testonly = True),
+    maven.artifact("org.apache.commons", "commons-compress", "1.21"),
+]
+
+COPYBARA_MAVEN_ARTIFACT_ADDITIONAL_REPOSITORIES = [
+    "https://maven.google.com",
+]
 
 def copybara_maven_repositories():
     maybe(
         maven_install,
         name = DEFAULT_REPOSITORY_NAME,
-        artifacts = [
-            "com.google.auto.value:auto-value-annotations:1.9",
-            "com.google.auto.value:auto-value:1.9",
-            "com.google.auto:auto-common:1.2.1",
-            "com.google.code.findbugs:jsr305:3.0.2",
-            "com.google.code.gson:gson:jar:2.8.5",
-            "com.google.flogger:flogger-system-backend:0.7.4",
-            "com.google.flogger:flogger:0.7.4",
-            "com.google.guava:failureaccess:1.0.1",
-            "com.google.guava:guava-testlib:31.1-jre",
-            "com.google.guava:guava:31.1-jre",
-            "com.google.http-client:google-http-client-gson:jar:1.27.0",
-            "com.google.http-client:google-http-client-test:jar:1.27.0",
-            "com.google.http-client:google-http-client:jar:1.27.0",
-            "com.google.jimfs:jimfs:1.2",
-            "com.google.re2j:re2j:1.6",
-            "com.google.testparameterinjector:test-parameter-injector:1.8",
-            "com.google.truth:truth:1.1.3",
-            "com.google.truth.extensions:truth-java8-extension:0.41",
-            "com.googlecode.java-diff-utils:diffutils:1.3.0",
-            "commons-codec:commons-codec:jar:1.11",
-            "junit:junit:4.13.2",
-            "net.bytebuddy:byte-buddy-agent:1.9.10",
-            "net.bytebuddy:byte-buddy:1.9.10",
-            "org.mockito:mockito-core:4.5.1",
-            "org.objenesis:objenesis:1.0",
-            "org.apache.commons:commons-compress:1.21",
-        ],
-        repositories = [
-            "https://maven.google.com",
-            "https://repo1.maven.org/maven2",
-        ],
+        artifacts = COPYBARA_MAVEN_ARTIFACTS,
+        repositories = COPYBARA_MAVEN_ARTIFACT_ADDITIONAL_REPOSITORIES + ["https://repo1.maven.org/maven2"],
     )


### PR DESCRIPTION
Inspired by https://github.com/grpc/grpc-java/blob/050cdb14fe3ee9508ab3849ea38495edd47d904f/repositories.bzl#L5-L49

Allow for copybara's Maven artifacts to be loaded into your own workspace's `maven_install()` call.

Additionally, upgrade rules_jvm_external and apply testonly/neverlink where I thought it would apply.