### PR TITLE
Update `Dockerfile` to use latest `go install` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN mkdir -p /tmp/copybara && \
     cp bazel-bin/java/com/google/copybara/copybara_deploy.jar /tmp/copybara/
 
 FROM golang:latest AS buildtools
-RUN go get github.com/bazelbuild/buildtools/buildozer
-RUN go get github.com/bazelbuild/buildtools/buildifier
+RUN go install github.com/bazelbuild/buildtools/buildozer@latest
+RUN go install github.com/bazelbuild/buildtools/buildifier@latest
 
 FROM openjdk:11-jre-slim
 WORKDIR /usr/src/app


### PR DESCRIPTION
This fixes the following errors while building the image:

```
 > [buildtools 2/3] RUN go get github.com/bazelbuild/buildtools/buildozer:
#15 0.610 go: go.mod file not found in current directory or any parent directory.
#15 0.610 	'go get' is no longer supported outside a module.
#15 0.610 	To build and install a command, use 'go install' with a version,
#15 0.610 	like 'go install example.com/cmd@latest'
#15 0.610 	For more information, see https://golang.org/doc/go-get-install-deprecation
#15 0.610 	or run 'go help get' or 'go help install'.
```

```
 > [buildtools 2/3] RUN go install github.com/bazelbuild/buildtools/buildozer:
#15 0.261 go: 'go install' requires a version when current directory is not in a module
#15 0.261 	Try 'go install github.com/bazelbuild/buildtools/buildozer@latest' to install the latest version
```