### PR TITLE
repositories: pinning platforms to latest version

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -25,6 +25,16 @@ def copybara_repositories():
 
     maybe(
         http_archive,
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        ],
+        sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+    )
+
+    maybe(
+        http_archive,
         name = "rules_jvm_external",
         sha256 = RULES_JVM_EXTERNAL_SHA,
         strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,


### PR DESCRIPTION
In Bazel versions from 5.1.0 and older, there was a change [1] which
prevents copybara from compiling on Apple Silicon by default.

The solution recommended in [2] was to pin `platforms` repository to a
newer version where the constraints value for CPP toolchain could be
correctly resolved.

Without this change, we would need to use Bazel 5.0.0 or older to
compile copybara successfully on Apple Silicon.

[1]: https://github.com/bazelbuild/bazel/pull/14844
[2]: https://github.com/bazelbuild/bazel/issues/15175