### PR TITLE
Generate GIT_REVNUM sequential commit labels

### DIFF
--- a/java/com/google/copybara/git/GitRepository.java
+++ b/java/com/google/copybara/git/GitRepository.java
@@ -160,6 +160,7 @@ public class GitRepository {
   public static final String GIT_DESCRIBE_REQUESTED_VERSION = "GIT_DESCRIBE_REQUESTED_VERSION";
   public static final String GIT_DESCRIBE_CHANGE_VERSION = "GIT_DESCRIBE_CHANGE_VERSION";
   public static final String GIT_DESCRIBE_FIRST_PARENT = "GIT_DESCRIBE_FIRST_PARENT";
+  public static final String GIT_SEQUENTIAL_REVISION_NUMBER = "GIT_SEQUENTIAL_REVISION_NUMBER";
   // Closest tag, if any
   public static final String GIT_DESCRIBE_ABBREV = "GIT_DESCRIBE_ABBREV";
   public static final String HTTP_PERMISSION_DENIED = "The requested URL returned error: 403";

--- a/java/com/google/copybara/git/GitRevision.java
+++ b/java/com/google/copybara/git/GitRevision.java
@@ -26,6 +26,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.copybara.exception.RepoException;
 import com.google.copybara.git.GitRepository.GitLogEntry;
 import com.google.copybara.revision.Revision;
+import com.google.copybara.util.CommandOutput;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,6 +46,7 @@ public final class GitRevision implements Revision {
   @Nullable private final String reviewReference;
   @Nullable private final String url;
   private String describe;
+  private String revisionNumber;
   /**
    * Create a git revision from a complete (40 characters) git SHA-1 string.
    *
@@ -185,6 +187,9 @@ public final class GitRevision implements Revision {
     if (label.equals(GitRepository.GIT_DESCRIBE_CHANGE_VERSION)) {
       return populateDescribe();
     }
+    if (label.equals(GitRepository.GIT_SEQUENTIAL_REVISION_NUMBER)) {
+      return populateRevisionNumber();
+    }
     return associatedLabels.get(label);
   }
 
@@ -208,6 +213,21 @@ public final class GitRevision implements Revision {
       }
     }
     return ImmutableList.of(describe);
+  }
+
+  /** Lazily compute rev number. */
+  private synchronized ImmutableList<String> populateRevisionNumber() {
+    if (revisionNumber == null) {
+      try {
+        CommandOutput cmdout = repository.simpleCommand("rev-list", "--count", sha1);
+        revisionNumber = cmdout.getStdout().trim();
+      } catch (RepoException e) {
+        logger.atWarning().withCause(e).log(
+            "Cannot get revision number for %s. Using short sha", sha1);
+        revisionNumber = "";
+      }
+    }
+    return ImmutableList.of(revisionNumber);
   }
 
   GitRevision withUrl(String url) {

--- a/javatests/com/google/copybara/git/GitOriginTest.java
+++ b/javatests/com/google/copybara/git/GitOriginTest.java
@@ -644,10 +644,16 @@ public class GitOriginTest {
     assertThat(changes.get(1).getRevision().associatedLabel("GIT_DESCRIBE_CHANGE_VERSION"))
         .contains("0.1-1-g" + changes.get(1).getRevision().asString().substring(0, 7));
 
+    assertThat(changes.get(1).getRevision().associatedLabel("GIT_SEQUENTIAL_REVISION_NUMBER"))
+        .contains("3");
+
     assertThat(changes.get(2).getMessage()).isEqualTo("change4\n");
 
     assertThat(changes.get(2).getRevision().associatedLabel("GIT_DESCRIBE_CHANGE_VERSION")).
         contains("0.1-2-g" + changes.get(2).getRevision().asString().substring(0, 7));
+
+    assertThat(changes.get(2).getRevision().associatedLabel("GIT_SEQUENTIAL_REVISION_NUMBER"))
+        .contains("4");
 
     TransformWork work = TransformWorks.of(Paths.get(""), "some msg", console).withChanges(
         new Changes(changes.reverse(), ImmutableList.of())
@@ -668,6 +674,8 @@ public class GitOriginTest {
       assertThat(change.getDateTime())
           .isAtMost(ZonedDateTime.now(ZoneId.systemDefault()).plusSeconds(1));
     }
+
+    assertThat(work.getLabel("GIT_SEQUENTIAL_REVISION_NUMBER")).isEqualTo("4");
   }
 
   @Test


### PR DESCRIPTION
Hi - I'm looking for suggestions as to how to refactor this cleanly, without impacting the performance on the default codepath for every revision.

Is GitRevision the right class to do this? Perhaps moved to a separate function with Bazel method to retrieve it only when needed ?