### PR TITLE
[github_pr_destination] Don't require context reference if `pr_branch` is set

### DIFF
--- a/java/com/google/copybara/git/GitHubPrDestination.java
+++ b/java/com/google/copybara/git/GitHubPrDestination.java
@@ -337,14 +337,18 @@ public class GitHubPrDestination implements Destination<GitRevision> {
       return gitHubDestinationOptions.destinationPrBranch;
     }
     String contextReference = changeRevision.contextReference();
-    // We could do more magic here with the change identity. But this is already complex so we
-    // require  a group identity either provided by the origin or the workflow (Will be implemented
-    // later.
-    checkCondition(contextReference != null,
-        "git.github_pr_destination is incompatible with the current origin. Origin has to be"
-            + " able to provide the contextReference or use '%s' flag",
-        GitHubDestinationOptions.GITHUB_DESTINATION_PR_BRANCH);
-    String branchNameFromUser = getCustomBranchName(contextReference);
+
+    String branchNameFromUser = prBranch;
+    if (branchNameFromUser == null) {
+      // We could do more magic here with the change identity. But this is already complex so we
+      // require a group identity either provided by the origin or the workflow (Will be implemented
+      // later.
+      checkCondition(contextReference != null,
+          "git.github_pr_destination is incompatible with the current origin. Origin has to be"
+              + " able to provide the contextReference or use '%s' flag",
+          GitHubDestinationOptions.GITHUB_DESTINATION_PR_BRANCH);
+      branchNameFromUser = getCustomBranchName(contextReference);
+    }
     String branchName =
         branchNameFromUser != null
             ? branchNameFromUser

--- a/javatests/com/google/copybara/git/GitHubPrDestinationTest.java
+++ b/javatests/com/google/copybara/git/GitHubPrDestinationTest.java
@@ -128,10 +128,7 @@ public class GitHubPrDestinationTest {
         assertThrows(ValidationException.class, () -> d.newWriter(writerContext));
     assertThat(thrown)
         .hasMessageThat()
-        .contains(
-            "git.github_pr_destination is incompatible with the current origin."
-                + " Origin has to be able to provide the contextReference or use"
-                + " '--github-destination-pr-branch' flag");
+        .contains(GitHubPrDestination.MISSING_CONTEXT_REFERENCE_MESSAGE);
   }
 
   @Test
@@ -301,8 +298,42 @@ public class GitHubPrDestinationTest {
   }
 
   @Test
-  public void testTrimMessageForPrTitle()
+  public void testWrite_destinationPrBranchHasMissingLabel() {
+    assertThat(
+    assertThrows(
+        ValidationException.class,
+        () -> testBranchNameFromUser(
+            "copybara/import_foo_${MISSING}",
+            null,
+            null))).hasMessageThat().contains("MISSING");
+  }
+
+  @Test
+  public void testWrite_destinationPrBranchNoContextReferenceRequired()
       throws ValidationException, IOException, RepoException {
+    testBranchNameFromUser(
+        "copybara/import_foo",
+        "copybara/import_foo",
+        null
+    );
+  }
+
+  @Test
+  public void testWrite_destinationPrBranchContextExplicitlyReferenceRequired() {
+    assertThat(
+            assertThrows(
+                ValidationException.class,
+                () ->
+                    testBranchNameFromUser(
+                        "copybara/import_foo_${CONTEXT_REFERENCE}",
+                        null,
+                        null)))
+        .hasMessageThat()
+        .contains(GitHubPrDestination.MISSING_CONTEXT_REFERENCE_MESSAGE);
+  }
+
+  @Test
+  public void testTrimMessageForPrTitle() throws ValidationException, IOException, RepoException {
     options.githubDestination.destinationPrBranch = "feature";
 
     mockNoPullRequestsGet("feature");


### PR DESCRIPTION
forked from https://github.com/google/copybara/pull/226 to address requested changes.

This will allow copybara to succeed for the following origin:
```
git.origin(
    url = "https://github.com/google/copybara.git",
    ref = "b0f6c6bbb5828c95b2b1409b4e491865d969f679",
)
```

## Changes
Only fail on missing context reference when it is required.
* This appears to be a reasonable compromise given that there are many ways to create a Revision without context reference.
* Added appropriate tests.
* Add null handling for Revision in pr branch name resolution (as it's marked with Nullable, however *that* works.)
* Fail when labels other than CONTEXT_REFERENCE are used in the pr name. (bit of a bug -- previously, for any interpolated label would just reprint the label. Since no tests failed when fixed, it appears to be unexpected behaviour.)
* Side note: these files seem to have missed the goggle-java-format boat. :[

cc: @Yannic, @petemounce


