### PR TITLE
Mention --java_language_version and --tool_java_language_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ load("@com_github_google_copybara//:repositories.go.bzl", "copybara_go_repositor
 copybara_go_repositories()
 ```
 
+Add the following to your .bazelrc:
+```rc
+build --java_language_version=11
+build --tool_java_language_version=11
+```
+
 You can then build and run the Copybara tool from within your workspace:
 
 ```sh


### PR DESCRIPTION
Context: I just spent three days trying to build copybara in an external workspace and kept getting the following error (which is also mentioned in https://github.com/google/copybara/issues/221 ):
```
external/com_github_google_copybara/java/com/google/copybara/onboard/core/AskInputProvider.java:117: error: cannot find symbol
                    var unused = input.convert(s, resolver);
                    ^
  symbol:   class var
  location: class Mode
external/com_github_google_copybara/java/com/google/copybara/onboard/core/InputProviderResolverImpl.java:60: error: cannot find symbol
      var unused = generator.consumes();
      ^
  symbol:   class var
  location: class InputProviderResolverImpl
```

I realized that I needed to update my .bazelrc only after combing through the changes trying to find a clue as to how to fix the issue.

I'm pretty new to bazel external repositories, having mostly worked with blaze and Chromium's GN, but I thought mentioning this in the docs could help other developers starting with bazel.

If the fix is too obvious, feel free to ignore :)