### PR TITLE
fix copyright statements

### DIFF
--- a/javatests/com/google/copybara/monitor/BUILD
+++ b/javatests/com/google/copybara/monitor/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2018s Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/javatests/com/google/copybara/profiler/ConsoleProfilerListenerTest.java
+++ b/javatests/com/google/copybara/profiler/ConsoleProfilerListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019z Google Inc.
+ * Copyright (C) 2019 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javatests/com/google/copybara/transform/VerifyMatchTest.java
+++ b/javatests/com/google/copybara/transform/VerifyMatchTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016-2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.copybara.transform;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -224,7 +240,7 @@ public final class VerifyMatchTest {
 
     Path file1 = checkoutDir.resolve("file1.txt");
     writeFile(file1, "/*\n"
-        + " * Copyright (C) 2016 Google Inc.\n"
+        + " * Copyright (C) 2016" + " Google Inc.\n"
         + " *\n"
         + " * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
         + " * you may not use this file except in compliance with the License.\n"


### PR DESCRIPTION
Saw these while making Debian packages. They are pretty trivial so I understand if you have to make the changes yourself internally and publish, instead of accepting this PR.

I try not to touch copyright statements made by other people, but these were some clear errors/omissions.

- Fix typos in copyright years
- Add missing copyright statement, and break up spurious copyright statement in code to avoid confusing detection software.
