### PR TITLE
Fix bug in ListSubmodules() when submodule branch=.

### DIFF
--- a/java/com/google/copybara/git/GitRepository.java
+++ b/java/com/google/copybara/git/GitRepository.java
@@ -1364,7 +1364,7 @@ public class GitRepository {
       }
       String branch = getSubmoduleField(submoduleName, "branch");
       if (branch != null && branch.equals(".")) {
-        branch = "HEAD";
+        branch = null;
       }
       FileUtil.checkNormalizedRelative(path);
       // If the url is relative, construct a url using the parent module remote url.


### PR DESCRIPTION
Fix a bug where a submodule attribute of `branch=.` was being treated as `branch=HEAD`.

`branch=.` is a special value that means a submodule should use the same branch name as the parent branch (see https://git-scm.com/docs/git-submodule#:~:text=same%20name%20as%20the%20current%20branch).  Setting it to 'HEAD' is only correct if the main project's `HEAD` branch is being imported.  In particular, this breaks the import of older versions of projects that use `branch=.` (such at boostorg/boost starting at version 1.70).

It would be possible to plumb information of the main repo's branch name through to listSubmodules() to get the intended network savings here.  However, that's a more complex change.  Treating `branch=.` the same as the case where no branch is specified fixes the problem.

Tested:
  An import of github.com/boostorg/boost.git for at version 1.72 fails to load the submodules correctly, but works after applying this patch.