### PR TITLE
Fall back to using the process PWD in case PWD is not set

### DIFF
--- a/java/com/google/copybara/GeneralOptions.java
+++ b/java/com/google/copybara/GeneralOptions.java
@@ -154,7 +154,7 @@ public final class GeneralOptions implements Option {
    * Returns current working directory
    */
   public Path getCwd() {
-    return fileSystem.getPath(environment.get("PWD"));
+    return fileSystem.getPath(environment.getOrDefault("PWD", System.getProperty("user.dir")));
   }
 
   /**


### PR DESCRIPTION
When invoked without a shell (e.g. when using exec form of `ENTRYPOINT` in `Dockerfile`), the env var `PWD` is not set and Copybara fails with a Null Pointer Exception.

As the behavior of overwriting the `$PWD` environment variable is used in tests, the behavior should not change for the time being.

Therefore, use a graceful fallback to the real process working directory in case the environment variable is not set.