### PR TITLE
Remove `output_to_genfiles = True` from Starlark rule.

### DIFF
--- a/java/com/google/copybara/docs.bzl
+++ b/java/com/google/copybara/docs.bzl
@@ -47,7 +47,6 @@ doc_generator = rule(
         "out": attr.output(mandatory = True),
     },
     implementation = _doc_generator_impl,
-    output_to_genfiles = True,
 )
 
 def copybara_reference(name, *, out, libraries, template_file = None):


### PR DESCRIPTION
This causes the rule outputs to be placed in `blaze-bin` (the default) instead of `blaze-genfiles`.

This change is a no-op for the vast majority of Bazel uses, since Bazel already defaults `--incompatible_merge_genfiles_directory` to enabled, making the genfiles/bin distinction moot.