### PR TITLE
Use a seperate layer for final published docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/*Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,34 +16,35 @@ ARG BAZEL_VERSION=:7.1.0
 
 # Set up buildtools required
 FROM golang:latest AS buildtools
-RUN go install github.com/bazelbuild/buildtools/buildozer@latest
-RUN go install github.com/bazelbuild/buildtools/buildifier@latest
-
+RUN go install github.com/bazelbuild/buildtools/buildozer@latest github.com/bazelbuild/buildtools/buildifier@latest
 
 # Set up bazel env
 FROM gcr.io/bazel-public/bazel${BAZEL_VERSION} AS build
-WORKDIR .
+
 USER root
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y openjdk-17-jdk-headless && \
+    rm -rf /var/lib/apt/lists/*
 
-COPY --chown=ubuntu:root . . 
-RUN apt-get update --fix-missing
-RUN apt-get install -y openjdk-17-jdk openjdk-17-jre git locales mercurial lsb-release software-properties-common quilt
-RUN add-apt-repository ppa:git-core/ppa -y
-RUN apt-get install -y git
-RUN apt-get update 
-
-# cleanup apt cache afterwards to keep image size small
-RUN rm -rf /var/lib/apt/lists/*
 # Bazel does not allow running as root
 USER ubuntu
-RUN bazel build //java/com/google/copybara:copybara_deploy.jar --java_language_version=11 --tool_java_language_version=11 --java_runtime_version=remotejdk_11
-USER root
-RUN mkdir -p /opt/copybara && cp /home/ubuntu/bazel-bin/java/com/google/copybara/copybara_deploy.jar /opt/copybara/copybara_deploy.jar -r
-COPY --from=buildtools /go/bin/buildozer /go/bin/buildifier /usr/bin/
-USER ubuntu
 
+WORKDIR /home/ubuntu/
+COPY . . 
+
+RUN bazel build //java/com/google/copybara:copybara_deploy.jar --java_language_version=11 --tool_java_language_version=11 --java_runtime_version=remotejdk_11
+
+# Use jammy to drop Python 2
+FROM docker.io/eclipse-temurin:17-jre-jammy
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git mercurial quilt && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=buildtools /go/bin/buildozer /go/bin/buildifier /usr/local/bin/
+COPY --from=build /home/ubuntu/bazel-bin/java/com/google/copybara/copybara_deploy.jar /opt/copybara/copybara_deploy.jar
 COPY .docker/copybara /usr/local/bin/copybara
+
 ENTRYPOINT ["/usr/local/bin/copybara"]
 CMD ["migrate", "copy.bara.sky"]
 WORKDIR /usr/src/app
-


### PR DESCRIPTION
Shaves off about 1.5G for the image size.

Signed-off-by: Zephyr Lykos \<git@mochaa.ws>
