### PR TITLE
Support `log.showSignature = true` in `.gitconfig`

### DIFF
--- a/java/com/google/copybara/git/GitRepository.java
+++ b/java/com/google/copybara/git/GitRepository.java
@@ -2358,7 +2358,7 @@ public class GitRepository {
      * Run 'git log' and returns zero or more {@link GitLogEntry}.
      */
     public ImmutableList<GitLogEntry> run() throws RepoException {
-      List<String> cmd = Lists.newArrayList("log", "--no-color", createFormat(includeBody));
+      List<String> cmd = Lists.newArrayList("-c", "log.showSignature=false", "log", "--no-color", createFormat(includeBody));
 
       if (limit > 0) {
         cmd.add("-" + limit);


### PR DESCRIPTION
If user has a setting to show GPG signatures, Copybara breaks:
```
[log]
    showSignature = true
```

```
java.lang.IllegalArgumentException: Chunk [ture made Mon 06 May 2024 03:15:22 PM UTC] is not a valid entry
  at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218)
  at com.google.common.base.Splitter$MapSplitter.split(Splitter.java:526)
  at com.google.copybara.git.GitRepository$LogCmd.parseLog(GitRepository.java:2428)
  at com.google.copybara.git.GitRepository$LogCmd.run(GitRepository.java:2404)
  at com.google.copybara.git.ChangeReader.run(ChangeReader.java:108)
  at com.google.copybara.git.GitOrigin$ReaderImpl.changes(GitOrigin.java:506)
  at com.google.copybara.git.GitOrigin$ReaderImpl.changes(GitOrigin.java:291)
  at com.google.copybara.WorkflowRunHelper.getChanges(WorkflowRunHelper.java:285)
  at com.google.copybara.WorkflowMode$1.run(WorkflowMode.java:84)
  at com.google.copybara.Workflow.run(Workflow.java:296)
  at com.google.copybara.MigrateCmd.run(MigrateCmd.java:92)
  at com.google.copybara.MigrateCmd.run(MigrateCmd.java:69)
  at com.google.copybara.Main.runInternal(Main.java:246)
  at com.google.copybara.Main.run(Main.java:128)
  at com.google.copybara.Main.main(Main.java:106)
ERROR: Unexpected error (please file a bug against copybara): Chunk [ture made Mon 06 May 2024 03:15:22 PM UTC] is not a valid entry (java.lang.IllegalArgumentException: Chunk [ture made Mon 06 May 2024 03:15:22 PM UTC] is not a valid entry)
```