### PR TITLE
chore: include release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Bazel
+      - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
@@ -42,12 +42,13 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.date }}
-          release_name: Release v${{ env.date }}
+          name: Release v${{ env.date }}
+          generate_release_notes: true
           body: |
             Automated weekly test release snapshot from master branch.
             This is a test release, version compatibility or correctness


### PR DESCRIPTION
This lets users easily see what has changed, and whether a given commit/PR is included in the latest release.

GitHub does a nice job generating this automatically: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes