### PR TITLE
copybara: adding a modifiable base url

### DIFF
--- a/java/com/google/copybara/BUILD
+++ b/java/com/google/copybara/BUILD
@@ -49,6 +49,7 @@ java_library(
         ":base",
         ":copybara_lib",
         ":general_options",
+        ":base_url_config",
         "//java/com/google/copybara/config:base",
         "//java/com/google/copybara/exception",
         "//java/com/google/copybara/jcommander:converters",
@@ -305,4 +306,10 @@ bzl_library(
     srcs = ["docs.bzl"],
     visibility = ["//visibility:private"],
     deps = ["@rules_java//java:rules"],
+)
+
+java_library(
+    name = "base_url_config",
+    srcs = ["BaseUrlConfig.java"],
+    javacopts = JAVACOPTS,
 )

--- a/java/com/google/copybara/BaseUrlConfig.java
+++ b/java/com/google/copybara/BaseUrlConfig.java
@@ -1,0 +1,16 @@
+package com.google.copybara;
+
+import java.util.Optional;
+ 
+public class BaseUrlConfig {
+    private static final String DEFAULT_BASE_URL = "https://github.com/";
+    private static String baseUrl;
+ 
+    public static void setBaseUrl(String url) {
+        baseUrl = url;
+    }
+ 
+    public static String getBaseUrl() {
+        return Optional.ofNullable(baseUrl).orElse(DEFAULT_BASE_URL);
+    }
+}

--- a/java/com/google/copybara/Main.java
+++ b/java/com/google/copybara/Main.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
+import com.google.copybara.BaseUrlConfig;
 import com.google.copybara.MainArguments.CommandWithArgs;
 import com.google.copybara.config.ConfigValidator;
 import com.google.copybara.config.Migration;
@@ -128,7 +129,6 @@ public class Main {
     console.verboseFmt("Running: %s", Joiner.on(' ').join(args));
 
     console.startupMessage(getVersion());
-
     CommandResult result = runInternal(args, console, fs);
     try {
       shutdown(result);
@@ -212,6 +212,7 @@ public class Main {
 
     try {
       ModuleSet moduleSet = newModuleSet(environment, fs, console);
+      BaseUrlConfig.setBaseUrl("");
 
       final MainArguments mainArgs = new MainArguments(ImmutableList.copyOf(args));
       Options options = moduleSet.getOptions();

--- a/java/com/google/copybara/git/BUILD
+++ b/java/com/google/copybara/git/BUILD
@@ -50,6 +50,7 @@ java_library(
     deps = [
         ":core",
         ":creds",
+        "//java/com/google/copybara:base_url_config",
         "//java/com/google/copybara:base",
         "//java/com/google/copybara:general_options",
         "//java/com/google/copybara:labels",

--- a/java/com/google/copybara/git/GitHubPrDestination.java
+++ b/java/com/google/copybara/git/GitHubPrDestination.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
+import com.google.copybara.BaseUrlConfig;
 import com.google.copybara.ChangeMessage;
 import com.google.copybara.Destination;
 import com.google.copybara.Endpoint;
@@ -346,7 +347,7 @@ public class GitHubPrDestination implements Destination<GitRevision> {
   }
 
   private String asHttpsUrl() throws ValidationException {
-    return "https://github.com/" + getProjectName();
+    return "https://" + BaseUrlConfig.getBaseUrl() + getProjectName();
   }
 
   @VisibleForTesting

--- a/java/com/google/copybara/git/GitHubPrIntegrateLabel.java
+++ b/java/com/google/copybara/git/GitHubPrIntegrateLabel.java
@@ -16,6 +16,7 @@
 
 package com.google.copybara.git;
 
+import com.google.copybara.BaseUrlConfig;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.copybara.GeneralOptions;
@@ -39,7 +40,7 @@ class GitHubPrIntegrateLabel implements IntegrateLabel {
 
   private static final Pattern LABEL_PATTERN =
       Pattern.compile(
-          "https://github.com/([.a-zA-Z0-9_/-]+)/pull/([0-9]+)"
+          "https://([.a-zA-Z0-9_/-]+)/([.a-zA-Z0-9_/-]+)/pull/([0-9]+)"
               + " from ([^\\s\\r\\n]*)(?: ([0-9a-f]{7,40}))?");
 
   private final GitRepository repository;
@@ -76,7 +77,7 @@ class GitHubPrIntegrateLabel implements IntegrateLabel {
 
   @Override
   public String toString() {
-    return String.format("https://github.com/%s/pull/%d from %s%s", projectId, prNumber,
+    return String.format("https://%s/%s/pull/%d from %s%s",BaseUrlConfig.getBaseUrl(), projectId, prNumber,
         originBranch, sha1 != null ? " " + sha1 : "");
   }
 
@@ -88,8 +89,8 @@ class GitHubPrIntegrateLabel implements IntegrateLabel {
 
   @Override
   public GitRevision getRevision() throws RepoException, ValidationException {
-    String pr = "https://github.com/" + projectId + "/pull/" + prNumber;
-    String repoUrl = "https://github.com/" + projectId;
+    String pr = "https://" + BaseUrlConfig.getBaseUrl() + "/" + projectId + "/pull/" + prNumber;
+    String repoUrl = "https://"+ BaseUrlConfig.getBaseUrl() + "/" + projectId;
     GitRevision gitRevision = GitRepoType.GITHUB.resolveRef(repository, repoUrl, pr,
         generalOptions, /*describeVersion=*/ false, /*partialFetch*/ false, Optional.empty());
     if (sha1 == null) {

--- a/java/com/google/copybara/git/GitHubPrOrigin.java
+++ b/java/com/google/copybara/git/GitHubPrOrigin.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.copybara.BaselinesWithoutLabelVisitor;
+import com.google.copybara.BaseUrlConfig;
 import com.google.copybara.Endpoint;
 import com.google.copybara.GeneralOptions;
 import com.google.copybara.Origin;
@@ -453,9 +454,9 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
     if (!forceImport() && branch != null && !Objects.equals(prData.getBase().getRef(), branch)) {
       throw new EmptyChangeException(
           String.format(
-              "Cannot migrate http://github.com/%s/pull/%d because its base branch is '%s', but"
+              "Cannot migrate http://%s/%s/pull/%d because its base branch is '%s', but"
                   + " the workflow is configured to only migrate changes for branch '%s'",
-              project, prData.getNumber(), prData.getBase().getRef(), branch));
+              BaseUrlConfig.getBaseUrl(), project, prData.getNumber(), prData.getBase().getRef(), branch));
     }
   }
 
@@ -488,9 +489,9 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
     if (!requiredButNotPresent.isEmpty()) {
       throw new EmptyChangeException(
           String.format(
-              "Cannot migrate http://github.com/%s/pull/%d because it is missing the following"
+              "Cannot migrate http://%s/%s/pull/%d because it is missing the following"
                   + " labels: %s",
-              project, prData.getNumber(), requiredButNotPresent));
+              BaseUrlConfig.getBaseUrl(), project, prData.getNumber(), requiredButNotPresent));
     }
   }
 
@@ -519,9 +520,9 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
       if (!requiredButNotPresent.isEmpty()) {
         throw new EmptyChangeException(
             String.format(
-                "Cannot migrate http://github.com/%s/pull/%d because the following ci labels "
+                "Cannot migrate http://%s/%s/pull/%d because the following ci labels "
                     + "have not been passed: %s",
-                project, prData.getNumber(), requiredButNotPresent));
+                BaseUrlConfig.getBaseUrl(), project, prData.getNumber(), requiredButNotPresent));
       }
     }
   }
@@ -549,9 +550,9 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
       if (!requiredButNotPresent.isEmpty()) {
         throw new EmptyChangeException(
             String.format(
-                "Cannot migrate http://github.com/%s/pull/%d because the following check runs "
+                "Cannot migrate http://%s/%s/pull/%d because the following check runs "
                     + "have not been passed: %s",
-                project, prData.getNumber(), requiredButNotPresent));
+                BaseUrlConfig.getBaseUrl(), project, prData.getNumber(), requiredButNotPresent));
       }
     }
   }
@@ -586,9 +587,9 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
       }
       throw new EmptyChangeException(
           String.format(
-              "Cannot migrate http://github.com/%s/pull/%d because it is missing the required"
+              "Cannot migrate http://%s/%s/pull/%d because it is missing the required"
                   + " approvals (origin is configured as %s).%s",
-              project, prData.getNumber(), reviewState, rejected));
+              BaseUrlConfig.getBaseUrl(), project, prData.getNumber(), reviewState, rejected));
     }
     Set<String> approvers = new HashSet<>();
     Set<String> others = new HashSet<>();

--- a/java/com/google/copybara/git/GitHubWriteHook.java
+++ b/java/com/google/copybara/git/GitHubWriteHook.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.flogger.FluentLogger;
+import com.google.copybara.BaseUrlConfig;
 import com.google.copybara.Endpoint;
 import com.google.copybara.GeneralOptions;
 import com.google.copybara.checks.Checker;
@@ -227,7 +228,7 @@ public class GitHubWriteHook extends DefaultWriteHook {
             String.format("Reference '%s' deleted", completeRef),
             ImmutableList.of(change),
             new DestinationRef(completeRef, "ref_deleted",
-                "https://github.com/" + projectId + "/tree/" + updatedPrBranchName)));
+                "https://"+ BaseUrlConfig.getBaseUrl() + "/" + projectId + "/tree/" + updatedPrBranchName)));
       } catch (GitHubApiException e) {
         if (e.getResponseCode() == ResponseCode.NOT_FOUND
             || e.getResponseCode() == ResponseCode.UNPROCESSABLE_ENTITY) {

--- a/java/com/google/copybara/git/GitRepoType.java
+++ b/java/com/google/copybara/git/GitRepoType.java
@@ -19,6 +19,7 @@ package com.google.copybara.git;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.flogger.FluentLogger;
+import com.google.copybara.BaseUrlConfig;
 import com.google.copybara.GeneralOptions;
 import com.google.copybara.doc.annotations.DocField;
 import com.google.copybara.exception.RepoException;
@@ -123,7 +124,7 @@ public enum GitRepoType {
         GitRepository repository, String repoUrl, String ref, GeneralOptions generalOptions,
         boolean describeVersion, boolean partialFetch, Optional<Integer> fetchDepth)
         throws RepoException, ValidationException {
-      if ((ref.startsWith("https://github.com") && ref.startsWith(repoUrl))
+      if ((ref.startsWith("https:/" + BaseUrlConfig.getBaseUrl()) && ref.startsWith(repoUrl))
           || GitHubUtil.maybeParseGithubPrFromMergeOrHeadRef(ref).isPresent()) {
         GitRevision ghPullRequest = maybeFetchGithubPullRequest(repository, repoUrl, ref,
             describeVersion, partialFetch);


### PR DESCRIPTION
in order to sync enterprise internal repos with the open source repos we need to get rid of the hardcoded github.com and make it a variable that can be modified via cmd-line