### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3394,7 +3394,6 @@ Parameter | Description
 Name | Type | Description
 ---- | ---- | -----------
 <span style="white-space: nowrap;">`--allstar-app-ids`</span> | *list* | Flag used to set AllStar GitHub app id aliases. See https://github.com/ossf/allstar.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3443,7 +3442,6 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-destination-push`</span> | *string* | If set, overrides the git destination push reference.
 <span style="white-space: nowrap;">`--git-destination-url`</span> | *string* | If set, overrides the git destination URL.
 <span style="white-space: nowrap;">`--git-skip-checker`</span> | *boolean* | If true and git.destination has a configured checker, it will not be used in the migration.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3452,7 +3450,7 @@ Name | Type | Description
 <a id="git.github_origin" aria-hidden="true"></a>
 ### git.github_origin
 
-Defines a Git origin for a Github repository. This origin should be used for public branches. Use github_pr_origin for importing Pull Requests.
+Defines a Git origin for a GitHub or GitHub Enterprise repository. This origin should be used for public branches. Use github_pr_origin for importing Pull Requests.
 
 <code><a href="#origin">origin</a></code> <code>git.github_origin(<a href=#git.github_origin.url>url</a>, <a href=#git.github_origin.ref>ref</a>=None, <a href=#git.github_origin.submodules>submodules</a>='NO', <a href=#git.github_origin.excluded_submodules>excluded_submodules</a>=[], <a href=#git.github_origin.first_parent>first_parent</a>=True, <a href=#git.github_origin.partial_fetch>partial_fetch</a>=False, <a href=#git.github_origin.patch>patch</a>=None, <a href=#git.github_origin.describe_version>describe_version</a>=None, <a href=#git.github_origin.version_selector>version_selector</a>=None, <a href=#git.github_origin.primary_branch_migration>primary_branch_migration</a>=False, <a href=#git.github_origin.enable_lfs>enable_lfs</a>=False, <a href=#git.github_origin.credentials>credentials</a>=None)</code>
 
@@ -3485,7 +3483,6 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-origin-log-batch`</span> | *int* | Read the origin git log in batches of n commits. Might be needed for large migrations resulting in git logs of more than 1 GB.
 <span style="white-space: nowrap;">`--git-origin-non-linear-history`</span> | *boolean* | Read the full git log and skip changes before the from ref rather than using a log path.
 <span style="white-space: nowrap;">`--git-origin-rebase-ref`</span> | *string* | When importing a change from a Git origin ref, it will be rebased to this ref, if set. A common use case: importing a Github PR, rebase it to the main branch (usually 'master'). Note that, if the repo uses submodules, they won't be rebased.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3581,7 +3578,6 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-destination-push`</span> | *string* | If set, overrides the git destination push reference.
 <span style="white-space: nowrap;">`--git-destination-url`</span> | *string* | If set, overrides the git destination URL.
 <span style="white-space: nowrap;">`--git-skip-checker`</span> | *boolean* | If true and git.destination has a configured checker, it will not be used in the migration.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--github-destination-pr-branch`</span> | *string* | If set, uses this branch for creating the pull request instead of using a generated one
@@ -3649,7 +3645,6 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-origin-log-batch`</span> | *int* | Read the origin git log in batches of n commits. Might be needed for large migrations resulting in git logs of more than 1 GB.
 <span style="white-space: nowrap;">`--git-origin-non-linear-history`</span> | *boolean* | Read the full git log and skip changes before the from ref rather than using a log path.
 <span style="white-space: nowrap;">`--git-origin-rebase-ref`</span> | *string* | When importing a change from a Git origin ref, it will be rebased to this ref, if set. A common use case: importing a Github PR, rebase it to the main branch (usually 'master'). Note that, if the repo uses submodules, they won't be rebased.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--github-force-import`</span> | *boolean* | Force import regardless of the state of the PR
@@ -3689,7 +3684,6 @@ Parameter | Description
 Name | Type | Description
 ---- | ---- | -----------
 <span style="white-space: nowrap;">`--allstar-app-ids`</span> | *list* | Flag used to set AllStar GitHub app id aliases. See https://github.com/ossf/allstar.
-<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3394,6 +3394,7 @@ Parameter | Description
 Name | Type | Description
 ---- | ---- | -----------
 <span style="white-space: nowrap;">`--allstar-app-ids`</span> | *list* | Flag used to set AllStar GitHub app id aliases. See https://github.com/ossf/allstar.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3442,6 +3443,7 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-destination-push`</span> | *string* | If set, overrides the git destination push reference.
 <span style="white-space: nowrap;">`--git-destination-url`</span> | *string* | If set, overrides the git destination URL.
 <span style="white-space: nowrap;">`--git-skip-checker`</span> | *boolean* | If true and git.destination has a configured checker, it will not be used in the migration.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3483,6 +3485,7 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-origin-log-batch`</span> | *int* | Read the origin git log in batches of n commits. Might be needed for large migrations resulting in git logs of more than 1 GB.
 <span style="white-space: nowrap;">`--git-origin-non-linear-history`</span> | *boolean* | Read the full git log and skip changes before the from ref rather than using a log path.
 <span style="white-space: nowrap;">`--git-origin-rebase-ref`</span> | *string* | When importing a change from a Git origin ref, it will be rebased to this ref, if set. A common use case: importing a Github PR, rebase it to the main branch (usually 'master'). Note that, if the repo uses submodules, they won't be rebased.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR
@@ -3578,6 +3581,7 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-destination-push`</span> | *string* | If set, overrides the git destination push reference.
 <span style="white-space: nowrap;">`--git-destination-url`</span> | *string* | If set, overrides the git destination URL.
 <span style="white-space: nowrap;">`--git-skip-checker`</span> | *boolean* | If true and git.destination has a configured checker, it will not be used in the migration.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--github-destination-pr-branch`</span> | *string* | If set, uses this branch for creating the pull request instead of using a generated one
@@ -3645,6 +3649,7 @@ Name | Type | Description
 <span style="white-space: nowrap;">`--git-origin-log-batch`</span> | *int* | Read the origin git log in batches of n commits. Might be needed for large migrations resulting in git logs of more than 1 GB.
 <span style="white-space: nowrap;">`--git-origin-non-linear-history`</span> | *boolean* | Read the full git log and skip changes before the from ref rather than using a log path.
 <span style="white-space: nowrap;">`--git-origin-rebase-ref`</span> | *string* | When importing a change from a Git origin ref, it will be rebased to this ref, if set. A common use case: importing a Github PR, rebase it to the main branch (usually 'master'). Note that, if the repo uses submodules, they won't be rebased.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--github-force-import`</span> | *boolean* | Force import regardless of the state of the PR
@@ -3684,6 +3689,7 @@ Parameter | Description
 Name | Type | Description
 ---- | ---- | -----------
 <span style="white-space: nowrap;">`--allstar-app-ids`</span> | *list* | Flag used to set AllStar GitHub app id aliases. See https://github.com/ossf/allstar.
+<span style="white-space: nowrap;">`--github-allowed-hosts`</span> | *list* | If using GitHub Enterprise, one needs to specify valid hosts. By default only `github.com` is supported.
 <span style="white-space: nowrap;">`--github-api-bearer-auth`</span> | *boolean* | If using a token for GitHub access, bearer auth might be required
 <span style="white-space: nowrap;">`--github-destination-delete-pr-branch`</span> | *boolean* | Overwrite git.github_destination delete_pr_branch field
 <span style="white-space: nowrap;">`--gql-commit-history-override`</span> | *list* | Flag used to target GraphQL params 'first' arguments in the event the defaults are over or underusing the api ratelimit. The flag value should be semicolon separated. This should be rarely used for repos that don't fit well in our defaults. E.g. '50;5;5' represent 50 commits, 5 PRs for each commit, 5 reviews per PR

--- a/java/com/google/copybara/git/BUILD
+++ b/java/com/google/copybara/git/BUILD
@@ -78,6 +78,7 @@ java_library(
         "//java/com/google/copybara/monitor",
         "//java/com/google/copybara/profiler",
         "//java/com/google/copybara/revision",
+        "//java/com/google/copybara/starlark",
         "//java/com/google/copybara/templatetoken",
         "//java/com/google/copybara/transform",
         "//java/com/google/copybara/transform/patch",

--- a/java/com/google/copybara/git/GitHubPrDestination.java
+++ b/java/com/google/copybara/git/GitHubPrDestination.java
@@ -234,7 +234,7 @@ public class GitHubPrDestination implements Destination<GitRevision> {
           return result.build();
         }
 
-        GitHubApi api = gitHubOptions.newGitHubRestApi(getProjectName(), credentials);
+        GitHubApi api = gitHubOptions.newGitHubRestApi(ghHost, getProjectName(), credentials);
 
         ImmutableList<PullRequest> pullRequests =
             api.getPullRequests(
@@ -346,7 +346,7 @@ public class GitHubPrDestination implements Destination<GitRevision> {
   }
 
   private String asHttpsUrl() throws ValidationException {
-    return "https://github.com/" + getProjectName();
+    return ghHost.projectAsUrl(getProjectName());
   }
 
   @VisibleForTesting

--- a/java/com/google/copybara/git/GitHubPrOrigin.java
+++ b/java/com/google/copybara/git/GitHubPrOrigin.java
@@ -269,7 +269,7 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
   /** Given a commit SHA, use the GitHub API to (try to) look up info for a corresponding PR. */
   private PullRequest getPrFromSha(String project, String sha)
       throws RepoException, ValidationException {
-    GitHubApi gitHubApi = gitHubOptions.newGitHubRestApi(project, credentials);
+    GitHubApi gitHubApi = gitHubOptions.newGitHubRestApi(ghHost, project, credentials);
     IssuesAndPullRequestsSearchResults searchResults =
         gitHubApi.getIssuesOrPullRequestsSearchResults(
             new IssuesAndPullRequestsSearchRequestParams(
@@ -299,13 +299,13 @@ public class GitHubPrOrigin implements Origin<GitRevision> {
   private PullRequest getPrFromNumber(String project, long prNumber)
       throws RepoException, ValidationException {
     try (ProfilerTask ignore = generalOptions.profiler().start("github_api_get_pr")) {
-      return gitHubOptions.newGitHubRestApi(project, credentials).getPullRequest(project, prNumber);
+      return gitHubOptions.newGitHubRestApi(ghHost, project, credentials).getPullRequest(project, prNumber);
     }
   }
 
   private GitRevision getRevisionForPR(String project, PullRequest prData)
       throws RepoException, ValidationException {
-    GitHubApi api = gitHubOptions.newGitHubRestApi(project, credentials);
+    GitHubApi api = gitHubOptions.newGitHubRestApi(ghHost, project, credentials);
     int prNumber = (int) prData.getNumber();
     boolean actuallyUseMerge = this.useMerge;
     ImmutableListMultimap.Builder<String, String> labels = ImmutableListMultimap.builder();

--- a/java/com/google/copybara/git/GitHubPrWriteHook.java
+++ b/java/com/google/copybara/git/GitHubPrWriteHook.java
@@ -95,7 +95,7 @@ public class GitHubPrWriteHook extends DefaultWriteHook {
     }
     for (Change<?> originalChange : originChanges) {
       String projectName = ghHost.getProjectNameFromUrl(repoUrl);
-      GitHubApi api = gitHubOptions.newGitHubRestApi(projectName, creds);
+      GitHubApi api = gitHubOptions.newGitHubRestApi(ghHost, projectName, creds);
 
       try {
         ImmutableList<PullRequest> pullRequests =

--- a/java/com/google/copybara/git/GitHubPreSubmitApprovalsProvider.java
+++ b/java/com/google/copybara/git/GitHubPreSubmitApprovalsProvider.java
@@ -202,7 +202,7 @@ public class GitHubPreSubmitApprovalsProvider implements ApprovalsProvider {
         ImmutableList.builder();
     ImmutableList<Review> reviews = null;
     try {
-      reviews = this.githubOptions.newGitHubRestApi(projectId, creds)
+      reviews = this.githubOptions.newGitHubRestApi(githubHost, projectId, creds)
           .getReviews(projectId, prNumber);
     } catch (RepoException | ValidationException e) {
       console.warnFmt(

--- a/java/com/google/copybara/git/GitHubWriteHook.java
+++ b/java/com/google/copybara/git/GitHubWriteHook.java
@@ -92,7 +92,7 @@ public class GitHubWriteHook extends DefaultWriteHook {
   private PullRequest getPrFromNumber(String project, long prNumber)
       throws RepoException, ValidationException {
     try (ProfilerTask ignore = generalOptions.profiler().start("github_api_get_pr")) {
-      return gitHubOptions.newGitHubRestApi(project, creds).getPullRequest(project, prNumber);
+      return gitHubOptions.newGitHubRestApi(ghHost, project, creds).getPullRequest(project, prNumber);
     }
   }
 
@@ -106,7 +106,7 @@ public class GitHubWriteHook extends DefaultWriteHook {
       throws ValidationException, RepoException {
 
     String configProjectName = ghHost.getProjectNameFromUrl(repoUrl);
-    GitHubApi api = gitHubOptions.newGitHubRestApi(configProjectName, creds);
+    GitHubApi api = gitHubOptions.newGitHubRestApi(ghHost, configProjectName, creds);
         
         
     // TODO(joshgoldman): add credentials to the GitRepository object for pushing to the fork
@@ -204,7 +204,7 @@ public class GitHubWriteHook extends DefaultWriteHook {
       return baseEffects.build();
     }
     String projectId = ghHost.getProjectNameFromUrl(repoUrl);
-    GitHubApi api = gitHubOptions.newGitHubRestApi(projectId, creds);
+    GitHubApi api = gitHubOptions.newGitHubRestApi(ghHost, projectId, creds);
 
     if (!originChanges.isEmpty()) {
       if (gitHubOptions.githubPrBranchDeletionDelay != null) {

--- a/java/com/google/copybara/git/GitModule.java
+++ b/java/com/google/copybara/git/GitModule.java
@@ -85,6 +85,7 @@ import com.google.copybara.git.github.api.AuthorAssociation;
 import com.google.copybara.git.github.api.CheckRun.Conclusion;
 import com.google.copybara.git.github.api.GitHubEventType;
 import com.google.copybara.git.github.api.GitHubGraphQLApi.GetCommitHistoryParams;
+import com.google.copybara.git.github.util.GitHubHost;
 import com.google.copybara.git.github.util.GitHubUtil;
 import com.google.copybara.git.gitlab.GitLabOptions;
 import com.google.copybara.git.gitlab.api.entities.MergeRequest.DetailedMergeStatus;
@@ -353,6 +354,10 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
     checkSubmoduleConfig(submodules, excludedSubmoduleList);
     String fixedUrl = fixHttp(url, thread.getCallerLocation());
     CredentialFileHandler credentialHandler = getCredentialHandler(fixedUrl, credentials);
+
+    GitHubOptions githubOptions = options.get(GitHubOptions.class);
+    boolean isGitHubUrl = githubOptions.isGithubUrl(url);
+
     return GitOrigin.newGitOrigin(
         options,
         fixedUrl,
@@ -369,7 +374,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
         validateVersionSelector(versionSelector),
         mainConfigFile.path(),
         workflowName,
-        GITHUB_COM.isGitHubUrl(url)
+        isGitHubUrl
             ? githubPostSubmitApprovalsProvider(
                 fixedUrl, SkylarkUtil.convertOptionalString(ref), credentialHandler)
             : approvalsProvider(url),
@@ -1157,7 +1162,8 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
       StarlarkThread thread)
       throws EvalException {
     checkNotEmpty(url, "url");
-    check(GITHUB_COM.isGitHubUrl(url), "Invalid Github URL: %s", url);
+    GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(url);
     PatchTransformation patchTransformation = maybeGetPatchTransformation(patch);
 
     List<String> excludedSubmoduleList =
@@ -1248,7 +1254,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
         patchTransformation,
         convertFromNoneable(branch, null),
         convertDescribeVersion(describeVersion),
-        GITHUB_COM,
+        ghHost,
         githubPreSubmitApprovalsProvider(fixedUrl, credHandler),
         credHandler);
   }
@@ -1387,7 +1393,8 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
       @Nullable Object credentials,
       StarlarkThread thread)
       throws EvalException {
-    check(GITHUB_COM.isGitHubUrl(checkNotEmpty(url, "url")), "Invalid Github URL: %s", url);
+    GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(checkNotEmpty(url, "url"));
 
     if (versionSelector != Starlark.NONE) {
       check(
@@ -1966,6 +1973,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
         branchToUpdate != null || deletePrBranch == null,
         "'delete_pr_branch' can only be set if 'pr_branch_to_update' is used");
     GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(url);
     WorkflowOptions workflowOptions = options.get(WorkflowOptions.class);
 
     String effectivePrBranchToUpdate = branchToUpdate;
@@ -1987,7 +1995,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
     CredentialFileHandler credentialHandler;
     try {
       credentialHandler = getCredentialHandler(
-          GITHUB_COM.getHost(), GITHUB_COM.getProjectNameFromUrl(url), credentials);
+              ghHost.getHost(), ghHost.getProjectNameFromUrl(url), credentials);
     } catch (ValidationException e) {
       throw new EvalException("Cannot parse url", e);
     }
@@ -2012,7 +2020,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
             effectiveDeletePrBranch,
             getGeneralConsole(),
             apiCheckerObj != null ? apiCheckerObj : checkerObj,
-            GITHUB_COM,
+            ghHost,
             credentialHandler,
             pushToFork),
         Starlark.isNullOrNone(integrates)
@@ -2265,18 +2273,18 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
       StarlarkThread thread)
       throws EvalException {
     GeneralOptions generalOptions = options.get(GeneralOptions.class);
-    // This restricts to github.com, we will have to revisit this to support setups like GitHub
-    // Enterprise.
-    check(GITHUB_COM.isGitHubUrl(url), "'%s' is not a valid GitHub url", url);
+
     GitDestinationOptions destinationOptions = options.get(GitDestinationOptions.class);
     GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
     String destinationPrBranch = convertFromNoneable(prBranch, null);
     Checker apiCheckerObj = convertFromNoneable(apiChecker, null);
     Checker checkerObj = convertFromNoneable(checker, null);
     CredentialFileHandler credentialHandler;
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(url);
+    check(ghHost.isGitHubUrl(url), "'%s' is not a valid GitHub url", url);
     try {
       credentialHandler = getCredentialHandler(
-          GITHUB_COM.getHost(), GITHUB_COM.getProjectNameFromUrl(url), credentials);
+          ghHost.getHost(), ghHost.getProjectNameFromUrl(url), credentials);
     } catch (ValidationException e) {
       throw new EvalException("Cannot parse url", e);
     }
@@ -2305,7 +2313,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
                     "empty_diff_merge_statuses")),
             convertSlugToConclusion(allowEmptyDiffCheckSuitesToConclusion),
             getGeneralConsole(),
-            GITHUB_COM,
+            ghHost,
             credentialHandler),
         Starlark.isNullOrNone(integrates)
             ? defaultGitIntegrate
@@ -2316,7 +2324,7 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
         mainConfigFile,
         apiCheckerObj != null ? apiCheckerObj : checkerObj,
         updateDescription,
-        GITHUB_COM,
+        ghHost,
         primaryBranchMigrationMode,
         checkerObj,
         credentialHandler);
@@ -2962,13 +2970,14 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
     Checker checker = convertFromNoneable(checkerObj, null);
     validateEndpointChecker(checker, GITHUB_API);
     GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(url);
     CredentialFileHandler credentialHandler = getCredentialHandler(url, credentials);
     return EndpointProvider.wrap(
         new GitHubEndPoint(
-            gitHubOptions.newGitHubApiSupplier(cleanedUrl, checker, credentialHandler, GITHUB_COM),
+            gitHubOptions.newGitHubApiSupplier(cleanedUrl, checker, credentialHandler, ghHost),
             cleanedUrl,
             getGeneralConsole(),
-            GITHUB_COM, credentialHandler));
+            ghHost, credentialHandler));
   }
 
   @SuppressWarnings("unused")
@@ -3158,19 +3167,20 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
     ImmutableSet<EventTrigger> parsedEvents = handleEventTypes(events, eventBuilder, types);
     validateEndpointChecker(checker, GITHUB_TRIGGER);
     GitHubOptions gitHubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = gitHubOptions.getGitHubHost(url);
     CredentialFileHandler credentialHandler;
     try {
       credentialHandler = getCredentialHandler(
-          GITHUB_COM.getHost(), GITHUB_COM.getProjectNameFromUrl(url), credentials);
+              ghHost.getHost(), ghHost.getProjectNameFromUrl(url), credentials);
     } catch (ValidationException e) {
       throw new EvalException("Cannot parse url", e);
     }
     return new GitHubTrigger(
-        gitHubOptions.newGitHubApiSupplier(url, checker, credentialHandler, GITHUB_COM),
+        gitHubOptions.newGitHubApiSupplier(url, checker, credentialHandler, ghHost),
         url,
         parsedEvents,
         getGeneralConsole(),
-        GITHUB_COM,
+        ghHost,
         credentialHandler);
   }
 
@@ -3389,28 +3399,29 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
 
   /** Do not use this for github origins */
   protected ApprovalsProvider approvalsProvider(String url) {
-    Preconditions.checkArgument(
-        !GITHUB_COM.isGitHubUrl(url),
-        "Git origins with github should use github approval providers!");
+      Preconditions.checkArgument(
+              !options.get(GitHubOptions.class).isGithubUrl(url),
+              "Git origins with github should use github approval providers!");
     return options.get(GitOriginOptions.class).approvalsProvider;
   }
 
-  protected ApprovalsProvider githubPreSubmitApprovalsProvider(
-      String url, CredentialFileHandler creds) {
+  protected ApprovalsProvider githubPreSubmitApprovalsProvider (
+      String url, CredentialFileHandler creds) throws EvalException {
     GeneralOptions generalOptions = options.get(GeneralOptions.class);
     GitHubOptions githubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = githubOptions.getGitHubHost(url);
     return new GitHubPreSubmitApprovalsProvider(
         githubOptions,
-        GITHUB_COM,
+            ghHost,
         new GitHubSecuritySettingsValidator(
-            githubOptions.newGitHubApiSupplier(url, null, creds, GITHUB_COM),
+            githubOptions.newGitHubApiSupplier(url, null, creds, ghHost),
             ImmutableList.copyOf(githubOptions.allStarAppIds),
             generalOptions.console()),
         new GitHubUserApprovalsValidator(
-            githubOptions.newGitHubApiSupplier(url, null, creds, GITHUB_COM),
-            githubOptions.newGitHubGraphQLApiSupplier(url, null, creds, GITHUB_COM),
+            githubOptions.newGitHubApiSupplier(url, null, creds, ghHost),
+            githubOptions.newGitHubGraphQLApiSupplier(url, null, creds, ghHost),
             generalOptions.console(),
-            GITHUB_COM,
+                ghHost,
             new GetCommitHistoryParams(
                 /* commits= */ githubOptions.gqlOverride.get(0),
                 /* pullRequests= */ githubOptions.gqlOverride.get(1),
@@ -3419,21 +3430,22 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
   }
 
   protected ApprovalsProvider githubPostSubmitApprovalsProvider(
-      String url, String branch, CredentialFileHandler creds) {
+      String url, String branch, CredentialFileHandler creds) throws EvalException {
     GeneralOptions generalOptions = options.get(GeneralOptions.class);
     GitHubOptions githubOptions = options.get(GitHubOptions.class);
+    GitHubHost ghHost = githubOptions.getGitHubHost(url);
     return new GitHubPostSubmitApprovalsProvider(
-        GITHUB_COM,
+        ghHost,
         branch,
         new GitHubSecuritySettingsValidator(
-            githubOptions.newGitHubApiSupplier(url, null, creds, GITHUB_COM),
+            githubOptions.newGitHubApiSupplier(url, null, creds, ghHost),
             ImmutableList.copyOf(githubOptions.allStarAppIds),
             generalOptions.console()),
         new GitHubUserApprovalsValidator(
-            githubOptions.newGitHubApiSupplier(url, null, creds, GITHUB_COM),
-            githubOptions.newGitHubGraphQLApiSupplier(url, null, creds, GITHUB_COM),
+            githubOptions.newGitHubApiSupplier(url, null, creds, ghHost),
+            githubOptions.newGitHubGraphQLApiSupplier(url, null, creds, ghHost),
             generalOptions.console(),
-            GITHUB_COM,
+            ghHost,
             new GetCommitHistoryParams(
                 /* commits= */ githubOptions.gqlOverride.get(0),
                 /* pullRequests= */ githubOptions.gqlOverride.get(1),
@@ -3505,9 +3517,15 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
   protected LazyResourceLoader<EndpointProvider<?>> maybeGetGitHubApi(
       String url, @Nullable Checker checker, @Nullable CredentialFileHandler creds,
       StarlarkThread thread) {
-    if (!GITHUB_COM.isGitHubUrl(url)) {
-      return null;
-    }
+      try {
+          GitHubOptions githubOptions = options.get(GitHubOptions.class);
+          GitHubHost ghHost = githubOptions.getGitHubHost(url);
+          if (!ghHost.isGitHubUrl(url)) {
+              return null;
+          }
+      } catch (EvalException e) {
+          return null;
+      }
     return (console) -> {
       try {
         return githubApi(url, checker, creds, thread);
@@ -3535,9 +3553,15 @@ public class GitModule implements LabelsAwareModule, StarlarkValue {
   @Nullable protected CredentialFileHandler getCredentialHandler(
       String url, @Nullable Object starlarkValue) {
     try {
-      if (GITHUB_COM.isGitHubUrl(url)) {
-        url = GITHUB_COM.normalizeUrl(url);
-      }
+        try {
+            GitHubOptions githubOptions = options.get(GitHubOptions.class);
+            GitHubHost ghHost = githubOptions.getGitHubHost(url);
+            if (ghHost.isGitHubUrl(url)) {
+                url = ghHost.normalizeUrl(url);
+            }
+        } catch (EvalException e) {
+            // nothing to-do, it is valid that this is not an GitHub URL.
+        }
       URI uri = URI.create(url);
       return getCredentialHandler(uri.getHost(), uri.getPath(), starlarkValue);
     } catch (ValidationException | IllegalArgumentException parseEx) {

--- a/java/com/google/copybara/git/GitRepoType.java
+++ b/java/com/google/copybara/git/GitRepoType.java
@@ -183,14 +183,17 @@ public enum GitRepoType {
   protected static GitRevision maybeFetchGithubPullRequest(GitRepository repository,
       String repoUrl, String ref, boolean describeVersion, boolean partialFetch)
       throws RepoException, ValidationException {
-    GitHubHost ghHost =  GitHubHost.fromUrl(repoUrl);
-    Optional<GitHubPrUrl> githubPrUrl = ghHost.maybeParseGithubPrUrl(ref);
+    if (GitHubHost.isGitHubUrl(repoUrl)) {
+
+    }
+    Optional<GitHubHost> ghHost =  Optional.ofNullable(GitHubHost.isGitHubUrl(repoUrl) ? GitHubHost.fromUrl(repoUrl) : null);
+    Optional<GitHubPrUrl> githubPrUrl = ghHost.flatMap(host -> host.maybeParseGithubPrUrl(ref));
     if (githubPrUrl.isPresent()) {
       // TODO(malcon): Support merge ref too once we have github pr origin.
       String stableRef = GitHubUtil.asHeadRef(githubPrUrl.get().getPrNumber());
       GitRevision gitRevision =
           repository.fetchSingleRefWithTags(
-              ghHost.getHostUrl() + githubPrUrl.get().getProject(),
+              ghHost.get().getHostUrl() + githubPrUrl.get().getProject(),
               stableRef,
               /* fetchTags= */ describeVersion,
               partialFetch,

--- a/java/com/google/copybara/git/GitRepoType.java
+++ b/java/com/google/copybara/git/GitRepoType.java
@@ -183,14 +183,14 @@ public enum GitRepoType {
   protected static GitRevision maybeFetchGithubPullRequest(GitRepository repository,
       String repoUrl, String ref, boolean describeVersion, boolean partialFetch)
       throws RepoException, ValidationException {
-    // TODO(malcon): This only supports github.com PRs, not enterprise.
-    Optional<GitHubPrUrl> githubPrUrl = GitHubHost.GITHUB_COM.maybeParseGithubPrUrl(ref);
+    GitHubHost ghHost =  GitHubHost.fromUrl(repoUrl);
+    Optional<GitHubPrUrl> githubPrUrl = ghHost.maybeParseGithubPrUrl(ref);
     if (githubPrUrl.isPresent()) {
       // TODO(malcon): Support merge ref too once we have github pr origin.
       String stableRef = GitHubUtil.asHeadRef(githubPrUrl.get().getPrNumber());
       GitRevision gitRevision =
           repository.fetchSingleRefWithTags(
-              "https://github.com/" + githubPrUrl.get().getProject(),
+              ghHost.getHostUrl() + githubPrUrl.get().getProject(),
               stableRef,
               /* fetchTags= */ describeVersion,
               partialFetch,

--- a/java/com/google/copybara/git/Mirror.java
+++ b/java/com/google/copybara/git/Mirror.java
@@ -37,6 +37,7 @@ import com.google.copybara.effect.DestinationEffect.DestinationRef;
 import com.google.copybara.exception.EmptyChangeException;
 import com.google.copybara.exception.RepoException;
 import com.google.copybara.exception.ValidationException;
+import com.google.copybara.git.github.util.GitHubHost;
 import com.google.copybara.monitor.EventMonitor.ChangeMigrationFinishedEvent;
 import com.google.copybara.profiler.Profiler;
 import com.google.copybara.profiler.Profiler.ProfilerTask;
@@ -248,7 +249,8 @@ public class Mirror implements Migration {
   private static String getOriginDestinationRef(String url) throws ValidationException {
     // TODO(copybara-team): This is used just for normalization. We should be able to do it without
     // knowing the host.
-    return GITHUB_COM.isGitHubUrl(url) ? GITHUB_COM.normalizeUrl(url) : url;
+    GitHubHost host = GitHubHost.fromUrl(url);
+    return host.isGitHubUrl(url) ? host.normalizeUrl(url) : url;
   }
 
   @VisibleForTesting

--- a/java/com/google/copybara/git/Mirror.java
+++ b/java/com/google/copybara/git/Mirror.java
@@ -249,8 +249,7 @@ public class Mirror implements Migration {
   private static String getOriginDestinationRef(String url) throws ValidationException {
     // TODO(copybara-team): This is used just for normalization. We should be able to do it without
     // knowing the host.
-    GitHubHost host = GitHubHost.fromUrl(url);
-    return host.isGitHubUrl(url) ? host.normalizeUrl(url) : url;
+    return GitHubHost.isGitHubUrl(url) ? GitHubHost.fromUrl(url).normalizeUrl(url) : url;
   }
 
   @VisibleForTesting

--- a/java/com/google/copybara/git/github/BUILD
+++ b/java/com/google/copybara/git/github/BUILD
@@ -42,6 +42,7 @@ java_library(
     ),
     javacopts = JAVACOPTS,
     deps = [
+        ":util",
         "//java/com/google/copybara/checks",
         "//java/com/google/copybara/doc:annotations",  # unuseddeps:keep
         "//java/com/google/copybara/exception",

--- a/java/com/google/copybara/git/github/util/GitHubHost.java
+++ b/java/com/google/copybara/git/github/util/GitHubHost.java
@@ -41,6 +41,12 @@ public class GitHubHost {
     this.gitHubPrUrlPattern = Pattern.compile("https://\\Q" + host + "\\E/(.+)/pull/([0-9]+)");
   }
 
+  static public GitHubHost fromUrl(String url)
+  {
+      url = url.replaceAll("http\\:\\/\\/|https\\:\\/\\/|git\\+|git@", "").replaceAll(":.*|/.*", "");
+      return new GitHubHost(url);
+  }
+
   /**
    * Return the username part of a github url. For example in https://github.com/foo/bar/baz, 'foo'
    * would be the user.
@@ -102,6 +108,10 @@ public class GitHubHost {
     return host;
   }
 
+  public String getHostUrl() {
+      return "https://" + host + "/";
+  }
+
   public String normalizeUrl(String url) throws ValidationException {
     return projectAsUrl(getProjectNameFromUrl(url));
   }
@@ -111,6 +121,17 @@ public class GitHubHost {
     return matcher.matches()
         ? Optional.of(new GitHubPrUrl(matcher.group(1), Integer.parseInt(matcher.group(2))))
         : Optional.empty();
+  }
+
+  public String getAPIEndpoint()
+  {
+    if(host.contains("github.com"))
+    {
+        return "https://api.github.com";
+    } else {
+        // https://docs.github.com/en/enterprise-server@3.16/rest/enterprise-admin?apiVersion=2022-11-28
+        return "https://" + host + "/api/v3";
+    }
   }
 
   /** A GitHub PR project and number */

--- a/java/com/google/copybara/rust/RustModule.java
+++ b/java/com/google/copybara/rust/RustModule.java
@@ -456,8 +456,8 @@ public class RustModule implements StarlarkValue {
   }
 
   private static String normalizeUrl(String url) throws ValidationException {
-    if (GitHubHost.GITHUB_COM.isGitHubUrl(url)) {
-      url = GitHubHost.GITHUB_COM.normalizeUrl(url);
+    if (GitHubHost.fromUrl(url).isGitHubUrl(url)) {
+      url = GitHubHost.fromUrl(url).normalizeUrl(url);
     }
     return url;
   }

--- a/java/com/google/copybara/rust/RustModule.java
+++ b/java/com/google/copybara/rust/RustModule.java
@@ -456,7 +456,7 @@ public class RustModule implements StarlarkValue {
   }
 
   private static String normalizeUrl(String url) throws ValidationException {
-    if (GitHubHost.fromUrl(url).isGitHubUrl(url)) {
+    if (GitHubHost.isGitHubUrl(url)) {
       url = GitHubHost.fromUrl(url).normalizeUrl(url);
     }
     return url;

--- a/javatests/com/google/copybara/git/GitHubPrDestinationTest.java
+++ b/javatests/com/google/copybara/git/GitHubPrDestinationTest.java
@@ -597,9 +597,7 @@ public class GitHubPrDestinationTest {
     ValidationException e =
         assertThrows(
             ValidationException.class, () -> checkFindProject("https://github.com", "foo"));
-    console
-        .assertThat()
-        .onceInLog(MessageType.ERROR, ".*'https://github.com' is not a valid GitHub url.*");
+    assertThat(e).hasMessageThat().containsMatch(".*Cannot parse url 'https://github.com'.*");
   }
 
   @Test

--- a/javatests/com/google/copybara/git/GitOriginTest.java
+++ b/javatests/com/google/copybara/git/GitOriginTest.java
@@ -337,6 +337,24 @@ public class GitOriginTest {
   }
 
   @Test
+  public void testGithubOriginForEnterpriseUrl() throws Exception {
+    options.github.gitHubAllowedHosts = ImmutableList.of("some.github-enterprise.net");
+    origin = skylark.eval("result",
+        "result = git.github_origin(\n"
+        + "    url = 'https://some.github-enterprise.net/copybara',\n"
+        + "    ref = 'main',\n"
+        + ")");
+    assertThat(origin.toString())
+        .isEqualTo(
+            "GitOrigin{"
+                + "repoUrl=https://some.github-enterprise.net/copybara, "
+                + "ref=main, "
+                + "repoType=GITHUB, "
+                + "primaryBranchMigrationMode=false"
+                + "}");
+  }
+
+  @Test
   public void testInvalidGithubUrl() throws Exception {
     ValidationException expected =
         assertThrows(
@@ -350,7 +368,7 @@ public class GitOriginTest {
                         + ")"));
     console
         .assertThat()
-        .onceInLog(MessageType.ERROR, ".*Invalid Github URL: https://foo.com/copybara.*");
+        .onceInLog(MessageType.ERROR, ".*'foo.com' is not a valid GitHub url.*");
   }
 
   @Test
@@ -367,7 +385,7 @@ public class GitOriginTest {
                         + ")"));
     console
         .assertThat()
-        .onceInLog(MessageType.ERROR, ".*Invalid Github URL: https://foo.com/github.com.*");
+            .onceInLog(MessageType.ERROR, ".*'foo.com' is not a valid GitHub url.*");
   }
 
   @Test

--- a/javatests/com/google/copybara/git/GitOriginTest.java
+++ b/javatests/com/google/copybara/git/GitOriginTest.java
@@ -338,7 +338,6 @@ public class GitOriginTest {
 
   @Test
   public void testGithubOriginForEnterpriseUrl() throws Exception {
-    options.github.gitHubAllowedHosts = ImmutableList.of("some.github-enterprise.net");
     origin = skylark.eval("result",
         "result = git.github_origin(\n"
         + "    url = 'https://some.github-enterprise.net/copybara',\n"
@@ -352,40 +351,6 @@ public class GitOriginTest {
                 + "repoType=GITHUB, "
                 + "primaryBranchMigrationMode=false"
                 + "}");
-  }
-
-  @Test
-  public void testInvalidGithubUrl() throws Exception {
-    ValidationException expected =
-        assertThrows(
-            ValidationException.class,
-            () ->
-                skylark.eval(
-                    "result",
-                    "result = git.github_origin(\n"
-                        + "    url = 'https://foo.com/copybara',\n"
-                        + "    ref = 'main',\n"
-                        + ")"));
-    console
-        .assertThat()
-        .onceInLog(MessageType.ERROR, ".*'foo.com' is not a valid GitHub url.*");
-  }
-
-  @Test
-  public void testInvalidGithubUrlWithGithubString() throws Exception {
-    ValidationException expected =
-        assertThrows(
-            ValidationException.class,
-            () ->
-                skylark.eval(
-                    "result",
-                    "result = git.github_origin(\n"
-                        + "    url = 'https://foo.com/github.com',\n"
-                        + "    ref = 'main',\n"
-                        + ")"));
-    console
-        .assertThat()
-            .onceInLog(MessageType.ERROR, ".*'foo.com' is not a valid GitHub url.*");
   }
 
   @Test

--- a/javatests/com/google/copybara/git/github/api/GitHubApiTest.java
+++ b/javatests/com/google/copybara/git/github/api/GitHubApiTest.java
@@ -31,6 +31,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.collect.ImmutableMap;
 import com.google.copybara.git.GitRepository;
 import com.google.copybara.git.github.api.testing.AbstractGitHubApiTest;
+import com.google.copybara.git.github.util.GitHubHost;
 import com.google.copybara.util.console.testing.TestingConsole;
 import java.io.IOException;
 import java.net.URI;
@@ -110,7 +111,7 @@ public class GitHubApiTest extends AbstractGitHubApiTest {
             return request;
           }
         };
-    return new GitHubApiTransportImpl(
+    return new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "some_storage_file", false, new TestingConsole());
   }
 

--- a/javatests/com/google/copybara/git/github/api/GitHubApiTransportImplTest.java
+++ b/javatests/com/google/copybara/git/github/api/GitHubApiTransportImplTest.java
@@ -32,6 +32,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.copybara.exception.RepoException;
 import com.google.copybara.git.GitRepository;
+import com.google.copybara.git.github.util.GitHubHost;
 import com.google.copybara.util.console.testing.TestingConsole;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -104,7 +105,7 @@ public class GitHubApiTransportImplTest {
         };
       }
     };
-    transport = new GitHubApiTransportImpl(
+    transport = new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "store", false, new TestingConsole());
     String unused = transport.get(String.class, "foo/bar");
     assertThat(headers).containsEntry("authorization", ImmutableList.of("Basic dXNlcjpTRUNSRVQ="));
@@ -127,7 +128,7 @@ public class GitHubApiTransportImplTest {
         };
       }
     };
-    transport = new GitHubApiTransportImpl(
+    transport = new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "store", true, new TestingConsole());
     String unused = transport.get(String.class, "foo/bar");
     assertThat(headers).containsEntry("authorization", ImmutableList.of("Bearer SECRET"));
@@ -137,7 +138,7 @@ public class GitHubApiTransportImplTest {
     HttpResponseException ex =
         new HttpResponseException.Builder(STATUS_CODE, ERROR_MESSAGE, new HttpHeaders()).build();
     httpTransport = createMockHttpTransport(ex);
-    transport = new GitHubApiTransportImpl(
+    transport = new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "store", false, new TestingConsole());
     try {
       c.call();
@@ -151,7 +152,7 @@ public class GitHubApiTransportImplTest {
   private void runTestThrowsIOException(Callable<?> c) throws Exception {
     IOException ioException = new IOException();
     httpTransport = createMockHttpTransport(ioException);
-    transport = new GitHubApiTransportImpl(
+    transport = new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "store", false,  new TestingConsole());
     try {
       c.call();

--- a/javatests/com/google/copybara/git/github/api/GitHubGraphQLTest.java
+++ b/javatests/com/google/copybara/git/github/api/GitHubGraphQLTest.java
@@ -29,6 +29,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.copybara.git.GitRepository;
 import com.google.copybara.git.github.api.testing.AbstractGitHubGraphQLApiTest;
+import com.google.copybara.git.github.util.GitHubHost;
 import com.google.copybara.util.console.testing.TestingConsole;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -105,7 +106,7 @@ public class GitHubGraphQLTest extends AbstractGitHubGraphQLApiTest {
             return request;
           }
         };
-    return new GitHubApiTransportImpl(
+    return new GitHubApiTransportImpl(GitHubHost.GITHUB_COM,
         repo, httpTransport, "some_storage_file", false, new TestingConsole());
   }
 


### PR DESCRIPTION
GitHub can be hosted by companies for their own usage (under their own URL).
This changset removes the hard-coded url to `github.com` and makes it confligurable for a user, which GitHub-instances shall be supported.

Closes #134