### PR TITLE
fix(git): Remove `Files.isHidden` guard in `AddExcludedFilesToIndex::prepare`

### DIFF
--- a/java/com/google/copybara/git/AddExcludedFilesToIndex.java
+++ b/java/com/google/copybara/git/AddExcludedFilesToIndex.java
@@ -70,10 +70,6 @@ final class AddExcludedFilesToIndex {
         addPathAndParents(included, relative);
       } else {
         prevExcluded.add(relative);
-        if (Files.isHidden(relative)) {
-          // File is not included but 'git add dir' doesn't work for 'dir/.file'.
-          addPathAndParents(included, relative.getParent());
-        }
       }
     }
 

--- a/javatests/com/google/copybara/git/GitDestinationTest.java
+++ b/javatests/com/google/copybara/git/GitDestinationTest.java
@@ -905,6 +905,35 @@ public class GitDestinationTest {
     assertThat(entry.files()).containsExactly("sub/tools/foo/other");
   }
 
+  /**
+   * Regression test for previously-excluded files inside a dot-directory. Earlier code called
+   * {@link java.nio.file.Files#isHidden} on each tree entry's relative path; on Windows that
+   * resolves against the JVM's current working directory and throws {@code NoSuchFileException}
+   * for any entry under e.g. {@code .github/}. The dot-directory case must produce a commit that
+   * preserves the destination-only files unchanged, on every platform.
+   */
+  @Test
+  public void testExcludes_dotDirectory_preserved() throws Exception {
+    fetch = primaryBranch;
+    push = primaryBranch;
+    GitTestUtil.writeFile(workdir, ".github/PULL_REQUEST_TEMPLATE.md", "destination-only");
+    GitTestUtil.writeFile(workdir, "src/included", "first");
+    repo().withWorkTree(workdir).add().all().run();
+    repo().withWorkTree(workdir).simpleCommand("commit", "-m", "first commit");
+
+    Files.delete(workdir.resolve("src/included"));
+    GitTestUtil.writeFile(workdir, "src/included", "second");
+    destinationFiles =
+        Glob.createGlob(ImmutableList.of("**"), ImmutableList.of(".github/**"));
+
+    process(newWriter(), new DummyRevision("origin_ref"));
+
+    assertThatCheckout(repo(), primaryBranch)
+        .containsFile(".github/PULL_REQUEST_TEMPLATE.md", "destination-only")
+        .containsFile("src/included", "second")
+        .containsNoMoreFiles();
+  }
+
   @Test
   public void processFetchRefDoesntExist() throws Exception {
     fetch = "testPullFromRef";


### PR DESCRIPTION
The goal of [prepare()](https://github.com/google/copybara/blob/f4f4f79ae155e00528f780ee209d5ae210beedae/java/com/google/copybara/git/AddExcludedFilesToIndex.java#L56) is to prepare a TreeSet<Path> `toExclude` which covers a set of arguments to pass to `git add` that cover all *destination-only* files in HEAD, without sweeping in any origin-owned file.

A check in line 73 defensively influences the algorithm to not assume that a `git add dir` also adds `dir/.file`, which is indicated in a surrounding comment:

https://github.com/google/copybara/blob/f4f4f79ae155e00528f780ee209d5ae210beedae/java/com/google/copybara/git/AddExcludedFilesToIndex.java#L73-L76

Therefore, in a minimal example, where `tools` is destination-owned and contains `tools/.keep` and `tools/script.sh`, we would end up with `toExclude = {tools/.keep, tools/script.sh}`.

However, git does not behave like indicated and a `git add dir` also adds any hidden subdirectories or files. Thus, it would be sufficient to run `git add tools` in the example above and not `git add tools/.keep tools/script.sh`. The code is overdefensive.

Therefore, this PR removes the `isHidden` check.

The reason why I am fixing this is that, also, `Files.isHidden(relative)` is broken on Windows: While on POSIX, `isHidden` simply checks if the basename starts with a dot, it checks a filesystem attribute on Windows. However, since the file path is relative, this happens relative to the current working directory of the JVM, which is not the checked-out repository. This issue could alternatively be fixed by resolving the file path first, but removing the `isHidden` check is the correct fix.

## Testing

I added a regression test, but I am not sure whether you run the CI on Windows as well. I still think it makes sense to keep.