### PR TITLE
Add --gerrit-unsafe-dont-check-for-dups.

### DIFF
--- a/java/com/google/copybara/git/GerritDestination.java
+++ b/java/com/google/copybara/git/GerritDestination.java
@@ -205,6 +205,11 @@ public final class GerritDestination implements Destination<GitRevision> {
 
     private Optional<ChangeInfo> findActiveChange(String hashTag)
         throws RepoException, ValidationException {
+      if (gerritOptions.unsafeDontCheckForDups) {
+        // --gerrit-unsafe-dont-check-for-dups: skip the REST query and behave as if no existing
+        // change was found.
+        return Optional.empty();
+      }
 
       console.progressFmt("Querying Gerrit ('%s') for active changes with hashtag '%s'",
           repoUrl, hashTag);

--- a/java/com/google/copybara/git/GerritOptions.java
+++ b/java/com/google/copybara/git/GerritOptions.java
@@ -89,6 +89,17 @@ public class GerritOptions implements Option {
       description = "Create a new change instead of trying to reuse an existing one.")
   protected boolean newChange = false;
 
+  @Parameter(
+      names = "--gerrit-unsafe-dont-check-for-dups",
+      description =
+          "UNSAFE: skip querying Gerrit (by the internal copybara hashtag) for an existing open"
+              + " change before creating one. Lets git.gerrit_destination run with no Gerrit REST"
+              + " call at all, e.g. against an ssh-only Gerrit URL. Cost: each run mints a fresh"
+              + " Change-Id, so re-running before a change is submitted _may_ create a duplicate"
+              + " change instead of a new patch set. Generated Change-Ids are stable so you"
+              + " might get lucky.")
+  protected boolean unsafeDontCheckForDups = false;
+
   @Parameter(names = "--gerrit-topic", description = "Gerrit topic to use")
   protected String gerritTopic = "";
 


### PR DESCRIPTION
Hope you can merge this - it is for a very local situation (Gerrit with no service account available and only SSH access feasible), but it's useful for anyone else in this situation and explicitly marked as unsafe to minimise footgun potential.

Option skips querying Gerrit for the internal copybara hashtag for an existing open change before creating one. Lets git.gerrit_destination run with no Gerrit REST calls needed.

Cost: each run mints a fresh Change-Id which are _mostly_ stable but there's no belt and braces dup checking so you might get duplicate Gerrit CLs.